### PR TITLE
Feature/pro imitator

### DIFF
--- a/addons/counterstrikesharp/plugins/ProImitator/.gitignore
+++ b/addons/counterstrikesharp/plugins/ProImitator/.gitignore
@@ -1,0 +1,9 @@
+# Build artifacts (regenerable by `dotnet build`)
+bin/
+obj/
+
+# JetBrains / Visual Studio user-specific files
+.idea/
+.vs/
+*.user
+*.suo

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -563,31 +563,46 @@ public class ProImitator : BasePlugin
 
         // ---------------------------------------------------------------------
         // KnifeRush: hold knife during the peaceful early-round rush phase
-        // (faster movement) and switch to the role weapon once contact is
-        // imminent. The window was opened in OnRoundFreezeEnd; we keep
-        // forcing knife per-tick until either:
-        //   - the window expires (KnifeRushSec elapsed since freeze end)
-        //   - the bot enters a duel (IsAimingAtEnemy goes true → AI takes
-        //     over, we step aside so the engine can pull the weapon).
+        // (faster movement: 260 u/s vs 215 rifle / 200 AWP) and switch to the
+        // role weapon once a real duel is imminent. Window was opened in
+        // OnRoundFreezeEnd.
         //
-        // When forceKnife is true we skip the Rifler / AWPer switch-back
-        // blocks below — otherwise they'd immediately undo our knife pull
-        // every tick.
+        // "Imminent duel" detection uses two signals:
+        //   - bot.IsAimingAtEnemy: the bot's AI has locked onto an enemy.
+        //     This is necessary but NOT sufficient — the bot AI sees long
+        //     sightlines, and at round-start on Dust2 a CT can lock onto a
+        //     T 3000 units away and we don't want that to break the knife
+        //     rush across the entire map.
+        //   - nearest enemy distance: an alive enemy of the opposite team
+        //     must be within KnifeRushCombatRangeUnits (~1500u, roughly mid-
+        //     Dust2 length). Below that we treat it as a real duel and pull
+        //     the role weapon.
+        //
+        // Once we decide to force knife, we re-issue `slot3` EVERY tick (no
+        // cooldown) until activeWeapon actually becomes a knife — the engine
+        // bot AI tries to re-pull primary aggressively and we need to outpace
+        // it. `slot3` is more reliable than `use weapon_*` for knives because
+        // the designer name varies by team / skin (weapon_knife_t, etc).
         // ---------------------------------------------------------------------
         bool inKnifeRush = _knifeRushUntil.TryGetValue(player.Slot, out float kRushUntil)
                         && now < kRushUntil;
-        bool inDuel      = bot.IsAimingAtEnemy;
-        bool forceKnife  = inKnifeRush && !inDuel;
+
+        bool inDuel = false;
+        if (inKnifeRush && bot.IsAimingAtEnemy)
+        {
+            inDuel = NearestEnemyWithinUnits(player, pawn, 1500f);
+        }
+        bool forceKnife = inKnifeRush && !inDuel;
 
         if (forceKnife)
         {
             bool holdingKnife = activeWeapon != null && activeWeapon.StartsWith("weapon_knife");
-            if (!holdingKnife
-                && (!_lastWeaponSwitchAt.TryGetValue(player.Slot, out float lastAtK)
-                    || now - lastAtK > WeaponSwitchCooldownSec))
+            if (!holdingKnife)
             {
-                NativeAPI.IssueClientCommand((int)player.Slot, "use weapon_knife");
-                _lastWeaponSwitchAt[player.Slot] = now;
+                NativeAPI.IssueClientCommand((int)player.Slot, "slot3");
+                // Intentionally no cooldown: re-issue every tick until the
+                // bot is actually on knife. Once holdingKnife=true the issue
+                // stops naturally.
             }
         }
 
@@ -637,6 +652,38 @@ public class ProImitator : BasePlugin
                 }
             }
         }
+    }
+    // -------------------------------------------------------------------------
+    // Is any alive opposing-team player within maxUnits of selfPawn? Used by
+    // KnifeRush to decide whether the bot is in an actual combat-range duel
+    // (pull weapon) or just locked on a long-distance enemy across the map
+    // (keep knife out).
+    //
+    // O(N) over all players each tick — N is at most 64 in CS2, negligible.
+    // -------------------------------------------------------------------------
+    private static bool NearestEnemyWithinUnits(CCSPlayerController self, CCSPlayerPawn selfPawn, float maxUnits)
+    {
+        if (selfPawn.AbsOrigin == null) return false;
+        CsTeam selfTeam = self.Team;
+        float maxSq = maxUnits * maxUnits;
+        float sx = selfPawn.AbsOrigin.X;
+        float sy = selfPawn.AbsOrigin.Y;
+        float sz = selfPawn.AbsOrigin.Z;
+
+        foreach (var p in Utilities.GetPlayers())
+        {
+            if (p == null || !p.IsValid) continue;
+            if (p.Team == selfTeam) continue;
+            var ePawn = p.PlayerPawn?.Value;
+            if (ePawn == null || !ePawn.IsValid || ePawn.AbsOrigin == null) continue;
+            if (ePawn.Health <= 0) continue;
+
+            float dx = sx - ePawn.AbsOrigin.X;
+            float dy = sy - ePawn.AbsOrigin.Y;
+            float dz = sz - ePawn.AbsOrigin.Z;
+            if (dx * dx + dy * dy + dz * dz < maxSq) return true;
+        }
+        return false;
     }
     // -------------------------------------------------------------------------
     // Walk the bot's weapon inventory and return the designer name of the

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -111,6 +111,16 @@ public class ProImitator : BasePlugin
     // comment in ApplyPersonality for the full design.
     private bool _bombPlanted = false;
 
+    // V4.4 — Bomb carrier run/walk coinflip state. Every CarrierRunFlipIntervalSec
+    // we roll 50/50 whether the carrier should be forced to IsRunning=true
+    // for the next interval. The cached decision avoids per-tick flicker
+    // (which at 64Hz would look like the bot is stuttering between run and
+    // walk) and produces a visible alternation across the round, which
+    // reads more like a human pro than V4.3's always-sprint behaviour.
+    private readonly Dictionary<int, float> _carrierRunFlipAt   = new();
+    private readonly Dictionary<int, bool>  _carrierRunDecision = new();
+    private const float CarrierRunFlipIntervalSec = 3.0f;
+
     // -------------------------------------------------------------------------
     public override void Load(bool hotReload)
     {
@@ -215,6 +225,8 @@ public class ProImitator : BasePlugin
             _wasAimingAtEnemy.Remove(player.Slot);
             _counterStrafeUntil.Remove(player.Slot);
             _knifeRushUntil.Remove(player.Slot);
+            _carrierRunFlipAt.Remove(player.Slot);
+            _carrierRunDecision.Remove(player.Slot);
         }
 
         return HookResult.Continue;
@@ -566,23 +578,18 @@ public class ProImitator : BasePlugin
         // small Duration values (10-20s) and removed CheckedHidingSpotCount=0
         // override.
         //
-        // V4.3 calibration (current): V4.2 was too soft on the defending
-        // side and the bomb carrier was indistinguishable from teammates.
-        // Three targeted bumps:
-        //   - CT (and post-plant T) defenders: HurryTimer EXPLICITLY cleared
-        //     (Duration=0, Timestamp=0). Critical because Entry-tagged bots
-        //     on the defending side still have AlwaysRushing in their
-        //     profile, which writes HurryTimer.Duration=600 every tick. If
-        //     BombFocus only writes SafeTime, the AlwaysRushing bot still
-        //     rushes — they look "agressifs trop de fight en dehors des BP".
-        //     The clear here wins the per-tick race against AlwaysRushing.
-        //   - Defender SafeTime raised 3s → 6s. Still not the V4.1 8s, but
-        //     more committed-to-position.
-        //   - Bomb carrier: HurryTimer 20s → 30s AND IsRunning forced true.
-        //     The forced run (no walk) is the visible difference between the
-        //     carrier and other Ts, without the V4.1 timer-wipe extremes
-        //     (SneakTimer / PoliteTimer / IsWaitingBehindFriend still
-        //     untouched — they can still use cover and trade).
+        // V4.3 added: defender HurryTimer cleared (wins the race vs
+        // AlwaysRushing for Entry-tagged defenders), SafeTime raised 3→6,
+        // carrier HurryTimer 20→30 + IsRunning forced.
+        //
+        // V4.4 calibration (current): always-on IsRunning for the carrier
+        // looked robotic. Now we 50/50 coinflip the run/walk decision on
+        // ~3s windows (see _carrierRunFlipAt + _carrierRunDecision state).
+        // Across a round the carrier visibly alternates pace, which reads
+        // as a real pro making situational decisions instead of a hold-W
+        // bot. The other V4.3 bumps (defender HurryTimer clear, SafeTime=6,
+        // carrier HurryTimer=30) stay as they are — those were the bits
+        // that actually fixed the CT-too-aggressive complaint.
         //
         // What BombFocus does per phase (V4.3 values):
         //   PRE-PLANT  T (attacker):  HurryTimer.Duration = 10s, refreshed
@@ -675,16 +682,20 @@ public class ProImitator : BasePlugin
 
             // Bomb carrier on pre-plant T-side: more site-focused than the
             // rest of the T side, but still strategic. V4.3 = HurryTimer
-            // 30s (vs 10s for other Ts) + IsRunning=true (always runs, no
-            // walk). The forced run is the visible "this bot is on
-            // mission" signal; the longer hurry horizon biases their path
-            // choice toward the assigned site.
+            // 30s (vs 10s for other Ts) + IsRunning=true (always runs).
             //
-            // V4.1's full timer wipe (SneakTimer / PoliteTimer /
-            // IsWaitingBehindFriend cleared) stays REMOVED — those wiped
+            // V4.4 calibration: always-on IsRunning was too robotic. Now
+            // we coin-flip every CarrierRunFlipIntervalSec (~3s) whether
+            // to force the run for the next interval. Half the time the
+            // carrier sprints, half the time they let the engine pick the
+            // pace (walk-carry, situational crouch, etc). Produces visible
+            // run/walk alternation across the round that reads as a real
+            // pro making situational pace decisions.
+            //
+            // V4.1's timer wipes (SneakTimer / PoliteTimer /
+            // IsWaitingBehindFriend cleared) stay REMOVED — those wiped
             // away the "strategic" behaviour the user wants the carrier
-            // to keep. They still use cover, still wait for trades, still
-            // pause at angles; they just run a bit faster toward the site.
+            // to keep.
             if (isT && !_bombPlanted && IsCarryingBomb(pawn))
             {
                 CountdownTimer hurry = bot.HurryTimer;
@@ -695,8 +706,21 @@ public class ProImitator : BasePlugin
                 ref float hurryTimestamp = ref hurry.Timestamp;
                 hurryTimestamp           = now + 30.0f;
 
-                ref bool isRunning = ref bot.IsRunning;
-                isRunning = true;
+                // 50/50 run/walk coinflip cached for CarrierRunFlipIntervalSec.
+                // Decision flips ~every 3 seconds so the carrier alternates
+                // visibly across the round rather than flickering each tick.
+                if (!_carrierRunFlipAt.TryGetValue(player.Slot, out float flipAt)
+                    || now > flipAt)
+                {
+                    _carrierRunDecision[player.Slot] = _rng.NextDouble() < 0.5;
+                    _carrierRunFlipAt[player.Slot]   = now + CarrierRunFlipIntervalSec;
+                }
+
+                if (_carrierRunDecision.GetValueOrDefault(player.Slot, false))
+                {
+                    ref bool isRunning = ref bot.IsRunning;
+                    isRunning = true;
+                }
             }
         }
 

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -69,6 +69,11 @@ public class ProImitator : BasePlugin
     private readonly Dictionary<int, float> _lastWeaponSwitchAt = new();
     private const float WeaponSwitchCooldownSec = 0.5f;
 
+    // Shared RNG for probability-gated traits (e.g. CounterStrafeChance).
+    // We don't seed it explicitly — System.Random's time-based seed is fine
+    // for "did the human pro mis-time their counter-strafe this round" rolls.
+    private readonly Random _rng = new();
+
     // CounterStrafes state. The pro behavior we're simulating: bot rushes,
     // first sees an enemy (IsAimingAtEnemy transitions false -> true), then
     // we kill its lateral velocity for ~120ms so the first tap lands with
@@ -372,25 +377,28 @@ public class ProImitator : BasePlugin
             checkedHidingSpotCount = 0;
         }
 
-        if (prof.CounterStrafes)
+        if (prof.CounterStrafeChance > 0f)
         {
             // Engagement-onset velocity kill. The pro tap-shot rhythm:
             //   rush -> see enemy -> *brief stop* -> first tap (accurate) -> resume
             //
-            // We detect the false->true edge of IsAimingAtEnemy and schedule
-            // ~120ms of zeroed lateral velocity. During that window, even if
-            // the bot's pathfinder is still trying to push forward, the
-            // velocity write each tick keeps it pinned in place.
+            // We detect the false->true edge of IsAimingAtEnemy. On the edge
+            // we roll a die against CounterStrafeChance; on a success we
+            // schedule ~120ms of zeroed lateral velocity. Probability < 1.0
+            // is what keeps the bot reading as a human: even top pros
+            // mis-time their counter-strafe sometimes, and a bot that does
+            // it perfectly every single engagement reads as aimbot.
             //
-            // Once the window expires, normal movement resumes — so this
-            // doesn't turn donk into a stationary turret in a sustained
-            // spray, just gives him the iconic mid-rush counter-strafe stop
-            // on EVERY new engagement.
+            // Once the window expires, normal movement resumes — sustained
+            // spray fights still see the bot strafing.
             bool isAimingAtEnemy = bot.IsAimingAtEnemy;
             bool wasAiming = _wasAimingAtEnemy.GetValueOrDefault(player.Slot, false);
 
             if (isAimingAtEnemy && !wasAiming)
-                _counterStrafeUntil[player.Slot] = now + CounterStrafeDurationSec;
+            {
+                if (_rng.NextDouble() <= prof.CounterStrafeChance)
+                    _counterStrafeUntil[player.Slot] = now + CounterStrafeDurationSec;
+            }
 
             if (_counterStrafeUntil.TryGetValue(player.Slot, out float until) && now < until)
             {
@@ -564,10 +572,14 @@ public sealed class ProProfile
     // pair with a coordinated BotBuy of `ak47` / `m4a1` / `aug` etc.
     public bool RifleOnly            { get; set; } = false;
 
-    // Counter-strafe at engagement onset. When the bot first sees an enemy
-    // (IsAimingAtEnemy transitions false->true), zero its lateral velocity
-    // for ~120ms so the first tap-shot lands with full standing-still
-    // accuracy. Pro-rusher signature; without this the bot run-and-guns and
-    // ALWAYS sprays which is visually wrong.
-    public bool CounterStrafes       { get; set; } = false;
+    // Counter-strafe at engagement onset, gated by probability so the bot
+    // doesn't read as aimbot. On the false->true edge of IsAimingAtEnemy
+    // we roll a die against this chance; on a success we zero lateral
+    // velocity for ~120ms (CounterStrafeDurationSec in ProImitator.cs).
+    //
+    // 0.0 = never counter-strafe (run-and-gun all engagements).
+    // 1.0 = always counter-strafe (perfect, reads as aimbot).
+    // 0.7 ~ 0.8 = pro-level: clean most of the time, occasionally misses
+    //             the timing like a real human.
+    public float CounterStrafeChance { get; set; } = 0f;
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -523,6 +523,89 @@ public class ProImitator : BasePlugin
             checkedHidingSpotCount = 0;
         }
 
+        // =====================================================================
+        // V4 — Objective awareness (BombFocus)
+        //
+        // Problem this addresses (reported during V3 testing):
+        //   Even with role-tuned aggression, CS2 bots default to "engage
+        //   whatever enemy I see, wherever I see them". On Dust2 this
+        //   produces rounds where Ts and CTs trade kills at mid for 1:45
+        //   and the bomb never gets planted. Tactical site execution and
+        //   coordinated defence are lost to fragfest behaviour.
+        //
+        // What BombFocus does (per-tick, when the trait flag is on):
+        //   T-SIDE: hard-max HurryTimer and clear CheckedHidingSpotCount so
+        //   the bot prioritises moving toward its assigned bombsite over
+        //   stopping for off-angle duels.  This stacks with AlwaysRushing
+        //   when both are set — same field writes, both intents agree.
+        //
+        //   CT-SIDE: extend SafeTime so the bot feels "safe at home" near
+        //   its assigned site. It defends the bomb plant rather than
+        //   wandering out toward mid for a long peek. Opposite intent of
+        //   NoSafeTime — these two should NOT both be set on a single
+        //   profile (mutually contradictory).
+        //
+        // What BombFocus deliberately does NOT do:
+        //   - Override the engine's bombsite assignment. CS2's nav system
+        //     decides which bot is "attacker of A vs attacker of B" at
+        //     scenario init; we don't touch that. We just nudge the timer
+        //     biases so the engine's existing plan executes more cleanly.
+        //   - Suppress combat. If an enemy actually crosses the bot's path,
+        //     normal engagement still happens. This is a *priority* bias,
+        //     not a passivity flag.
+        //   - Snapshot bomb-site entities. We rely on the engine knowing
+        //     where its own scenario objectives are; explicit nav-mesh
+        //     traversal from the C# side would be brittle and map-specific.
+        //
+        // Tuning notes for future maintainers:
+        //   The two field writes below are the smallest-footprint nudge we
+        //   could find that produced visible behaviour change in playtests.
+        //   If you add more aggressive overrides here (e.g. forcing
+        //   bot.Task or bot.GoalEntity), document the schema fields you
+        //   touch, because BotState may also write them and the load order
+        //   between the two plugins isn't guaranteed.
+        // =====================================================================
+        if (prof.BombFocus)
+        {
+            bool isT  = player.Team == CsTeam.Terrorist;
+            bool isCT = player.Team == CsTeam.CounterTerrorist;
+
+            if (isT)
+            {
+                // Max-out HurryTimer: bot stays in "rush toward goal" mode
+                // for the full round duration. Goal is decided by the
+                // engine's scenario system (the assigned bombsite).
+                CountdownTimer hurry = bot.HurryTimer;
+
+                ref float hurryDuration  = ref hurry.Duration;
+                hurryDuration            = 600.0f;
+
+                ref float hurryTimestamp = ref hurry.Timestamp;
+                hurryTimestamp           = now + 600.0f;
+
+                ref float hurryTimescale = ref hurry.Timescale;
+                hurryTimescale           = 1.0f;
+
+                // Skip hiding-spot checks while in transit — those are what
+                // makes a bot stop at mid-route corners. The engine still
+                // chooses a hiding spot once it ARRIVES at the site (which
+                // is what defence post-plant needs), this just shortens the
+                // approach phase.
+                ref int checkedHidingSpotCount = ref bot.CheckedHidingSpotCount;
+                checkedHidingSpotCount         = 0;
+            }
+            else if (isCT)
+            {
+                // Extend SafeTime: bot stays in "safe at home" perception
+                // longer, meaning it's less likely to peek out for distant
+                // duels. The engine still triggers full alertness once an
+                // enemy is actually nearby; this just stops the early-round
+                // mid-rush behaviour CTs sometimes show.
+                ref float safeTime = ref bot.SafeTime;
+                safeTime           = 8.0f;
+            }
+        }
+
         if (prof.CounterStrafeChance > 0f)
         {
             // Engagement-onset velocity kill. The pro tap-shot rhythm:
@@ -863,6 +946,25 @@ public sealed class ProProfile
     // 0.7 ~ 0.8 = pro-level: clean most of the time, occasionally misses
     //             the timing like a real human.
     public float CounterStrafeChance { get; set; } = 0f;
+
+    // V4 — Objective awareness. See the V4 banner block in ApplyPersonality
+    // for the full design discussion (problem, intent, limitations).
+    //
+    // T-side effect:  bot HurryTimer maxed, CheckedHidingSpotCount cleared.
+    //                 Pushes bot toward its assigned bombsite, less stopping
+    //                 for off-route duels.
+    // CT-side effect: bot SafeTime extended to 8s. Bot holds its assigned
+    //                 site rather than peeking out toward mid.
+    //
+    // Recommended for: Entry Fraggers, IGLs, Supports — roles that should
+    // execute the team plan. Leave OFF for Lurkers and AWPers (they play
+    // away from the main objective by design).
+    //
+    // Don't combine with NoSafeTime=true on the same profile: NoSafeTime
+    // forces SafeTime=0 every tick, BombFocus writes SafeTime=8 on CT-side
+    // every tick — the two would fight per-tick (last-write-wins) and the
+    // bot oscillates between alert and relaxed.
+    public bool BombFocus { get; set; } = false;
 
     // KnifeRush: hold knife during the peaceful early-round rush so the bot
     // gets the knife's movement bonus (~20% faster: 260 u/s vs 215 rifle,

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -94,6 +94,13 @@ public class ProImitator : BasePlugin
     private readonly Dictionary<int, float> _counterStrafeUntil = new();
     private const float CounterStrafeDurationSec = 0.12f;
 
+    // KnifeRush state. The pro round-opener: hold knife to gain ~20% movement
+    // speed (260 u/s vs 215 rifle / 200 AWP) during the peaceful rush phase,
+    // switch to weapon ~3s before expected contact. We track until-when the
+    // bot should hold knife (per-profile KnifeRushSec, set in OnRoundFreezeEnd).
+    // Per-tick logic forces knife if currently in window AND not in combat.
+    private readonly Dictionary<int, float> _knifeRushUntil = new();
+
     // -------------------------------------------------------------------------
     public override void Load(bool hotReload)
     {
@@ -102,6 +109,7 @@ public class ProImitator : BasePlugin
         RegisterEventHandler<EventPlayerSpawn>(OnPlayerSpawn);
         RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam);
         RegisterEventHandler<EventRoundStart>(OnRoundStart);
+        RegisterEventHandler<EventRoundFreezeEnd>(OnRoundFreezeEnd);
         RegisterListener<Listeners.OnTick>(OnTick);
 
         // Register commands as plain game console commands (mirrors how the
@@ -195,8 +203,32 @@ public class ProImitator : BasePlugin
             _lastWeaponSwitchAt.Remove(player.Slot);
             _wasAimingAtEnemy.Remove(player.Slot);
             _counterStrafeUntil.Remove(player.Slot);
+            _knifeRushUntil.Remove(player.Slot);
         }
 
+        return HookResult.Continue;
+    }
+    // -------------------------------------------------------------------------
+    // KnifeRush window opens when freeze ends — that's when bots actually start
+    // moving. We just record per-bot "hold knife until time T"; the actual
+    // forced knife switch is done per-tick in ApplyPersonality (so we can
+    // gracefully step aside the moment the bot enters a duel).
+    //
+    // Why not OnRoundStart: freeze can be long (15-20s) and there's no point
+    // holding knife while the bot is rooted in spawn. We want the knife hold
+    // to start the instant the bot can actually move.
+    // -------------------------------------------------------------------------
+    [GameEventHandler]
+    public HookResult OnRoundFreezeEnd(EventRoundFreezeEnd @event, GameEventInfo info)
+    {
+        if (_assigned.Count == 0) return HookResult.Continue;
+
+        float now = Server.CurrentTime;
+        foreach (var kvp in _assigned)
+        {
+            if (!kvp.Value.KnifeRush) continue;
+            _knifeRushUntil[kvp.Key] = now + kvp.Value.KnifeRushSec;
+        }
         return HookResult.Continue;
     }
     // -------------------------------------------------------------------------
@@ -529,7 +561,37 @@ public class ProImitator : BasePlugin
             _wasAimingAtEnemy[player.Slot] = isAimingAtEnemy;
         }
 
-        if (prof.Rifler)
+        // ---------------------------------------------------------------------
+        // KnifeRush: hold knife during the peaceful early-round rush phase
+        // (faster movement) and switch to the role weapon once contact is
+        // imminent. The window was opened in OnRoundFreezeEnd; we keep
+        // forcing knife per-tick until either:
+        //   - the window expires (KnifeRushSec elapsed since freeze end)
+        //   - the bot enters a duel (IsAimingAtEnemy goes true → AI takes
+        //     over, we step aside so the engine can pull the weapon).
+        //
+        // When forceKnife is true we skip the Rifler / AWPer switch-back
+        // blocks below — otherwise they'd immediately undo our knife pull
+        // every tick.
+        // ---------------------------------------------------------------------
+        bool inKnifeRush = _knifeRushUntil.TryGetValue(player.Slot, out float kRushUntil)
+                        && now < kRushUntil;
+        bool inDuel      = bot.IsAimingAtEnemy;
+        bool forceKnife  = inKnifeRush && !inDuel;
+
+        if (forceKnife)
+        {
+            bool holdingKnife = activeWeapon != null && activeWeapon.StartsWith("weapon_knife");
+            if (!holdingKnife
+                && (!_lastWeaponSwitchAt.TryGetValue(player.Slot, out float lastAtK)
+                    || now - lastAtK > WeaponSwitchCooldownSec))
+            {
+                NativeAPI.IssueClientCommand((int)player.Slot, "use weapon_knife");
+                _lastWeaponSwitchAt[player.Slot] = now;
+            }
+        }
+
+        if (prof.Rifler && !forceKnife)
         {
             // Pure preference: if the bot has a rifle in inventory but is
             // currently holding something else (pistol from auto-switch on
@@ -557,7 +619,7 @@ public class ProImitator : BasePlugin
             }
         }
 
-        if (prof.AWPer)
+        if (prof.AWPer && !forceKnife)
         {
             // AWPer mirror of the Rifler switch-back. Same cooldown, same
             // no-give policy: if the engine ever gave the bot an AWP / SSG08
@@ -754,4 +816,16 @@ public sealed class ProProfile
     // 0.7 ~ 0.8 = pro-level: clean most of the time, occasionally misses
     //             the timing like a real human.
     public float CounterStrafeChance { get; set; } = 0f;
+
+    // KnifeRush: hold knife during the peaceful early-round rush so the bot
+    // gets the knife's movement bonus (~20% faster: 260 u/s vs 215 rifle,
+    // 200 AWP). Switches back to the role weapon either after KnifeRushSec
+    // elapses OR the moment the bot enters a duel (whichever comes first).
+    //
+    // Real pros do this all the time on de_*: jog out with the knife,
+    // switch ~3s before expected contact. The "expected contact" varies by
+    // map and role — entry T sees enemies sooner than a CT AWPer holding
+    // a long angle — so KnifeRushSec is per-profile.
+    public bool  KnifeRush    { get; set; } = false;
+    public float KnifeRushSec { get; set; } = 5.0f;
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -121,6 +121,25 @@ public class ProImitator : BasePlugin
     private readonly Dictionary<int, bool>  _carrierRunDecision = new();
     private const float CarrierRunFlipIntervalSec = 3.0f;
 
+    // V4.5 — Debug logging toggle. Off by default; flip with `pro_debug`
+    // console command. When on, the plugin logs lifecycle events (round
+    // start, freeze end, bomb planted/dropped) and per-bot state changes
+    // (knife rush start/end, carrier detection, BombFocus phase) to the
+    // server console. Used to verify that traits are actually firing — if
+    // a behaviour looks broken in game and the logs show the codepath
+    // isn't running, the bug is upstream (event registration, profile
+    // load); if logs show the codepath IS running but in-game behaviour
+    // is wrong, the bug is the schema write or command.
+    private bool _debugLog = false;
+
+    // Per-bot state-change trackers for logging (edge-detected). Avoids
+    // spamming the console at 64Hz with the same state info every tick.
+    private readonly Dictionary<int, bool> _logKnifeForceWasActive = new();
+    private readonly Dictionary<int, bool> _logWasCarrier          = new();
+    // Last reported dropped-bomb seen-state for the "now defending dropped
+    // bomb" CT log — null = no dropped bomb last tick.
+    private bool _logBombWasDropped = false;
+
     // -------------------------------------------------------------------------
     public override void Load(bool hotReload)
     {
@@ -140,6 +159,7 @@ public class ProImitator : BasePlugin
         AddCommand("pro_list",     "List Pro-Imitator profiles loaded from disk",          OnProListCmd);
         AddCommand("pro_assigned", "List bots that currently have a Pro-Imitator profile", OnProAssignedCmd);
         AddCommand("pro_reload",   "Re-read JSON profiles from disk",                       OnProReloadCmd);
+        AddCommand("pro_debug",    "Toggle Pro-Imitator debug logging to server console",  OnProDebugCmd);
 
         Console.WriteLine($"[Pro-Imitator] loaded with {_profiles.Count} profile(s): "
                           + string.Join(", ", _profiles.Values.Select(p => p.Name)));
@@ -227,6 +247,8 @@ public class ProImitator : BasePlugin
             _knifeRushUntil.Remove(player.Slot);
             _carrierRunFlipAt.Remove(player.Slot);
             _carrierRunDecision.Remove(player.Slot);
+            _logKnifeForceWasActive.Remove(player.Slot);
+            _logWasCarrier.Remove(player.Slot);
         }
 
         return HookResult.Continue;
@@ -247,10 +269,20 @@ public class ProImitator : BasePlugin
         if (_assigned.Count == 0) return HookResult.Continue;
 
         float now = Server.CurrentTime;
+        int knifeRushCount = 0;
         foreach (var kvp in _assigned)
         {
             if (!kvp.Value.KnifeRush) continue;
             _knifeRushUntil[kvp.Key] = now + kvp.Value.KnifeRushSec;
+            knifeRushCount++;
+            if (_debugLog)
+            {
+                Console.WriteLine($"[Pro-Imitator-DBG] knife rush window opened slot={kvp.Key} profile={kvp.Value.Name} until=+{kvp.Value.KnifeRushSec:F1}s");
+            }
+        }
+        if (_debugLog)
+        {
+            Console.WriteLine($"[Pro-Imitator-DBG] OnRoundFreezeEnd: {_assigned.Count} profiled, {knifeRushCount} got knife rush windows");
         }
         return HookResult.Continue;
     }
@@ -280,7 +312,13 @@ public class ProImitator : BasePlugin
     {
         // Reset pre/post-plant state for the new round so BombFocus reverts
         // to its pre-plant intent (T = attacker, CT = defender).
-        _bombPlanted = false;
+        _bombPlanted        = false;
+        _logBombWasDropped  = false;
+
+        if (_debugLog)
+        {
+            Console.WriteLine($"[Pro-Imitator-DBG] OnRoundStart fired. assigned={_assigned.Count} bots, _bombPlanted reset to false");
+        }
 
         if (_assigned.Count == 0) return HookResult.Continue;
 
@@ -297,6 +335,10 @@ public class ProImitator : BasePlugin
     public HookResult OnBombPlanted(EventBombPlanted @event, GameEventInfo info)
     {
         _bombPlanted = true;
+        if (_debugLog)
+        {
+            Console.WriteLine("[Pro-Imitator-DBG] OnBombPlanted fired → switching to post-plant role inversion (T defender, CT attacker)");
+        }
         return HookResult.Continue;
     }
     // -------------------------------------------------------------------------
@@ -404,6 +446,19 @@ public class ProImitator : BasePlugin
 
         float now = Server.CurrentTime;
 
+        // V4.5 — Find dropped-bomb position once per tick, not per profiled bot.
+        // null if no bomb is currently dropped (carried, planted, or absent).
+        // Edge-log when state transitions for debug visibility.
+        Vector? droppedBombPos = _bombPlanted ? null : FindDroppedBombPosition();
+        bool bombDroppedNow = droppedBombPos != null;
+        if (_debugLog && bombDroppedNow != _logBombWasDropped)
+        {
+            Console.WriteLine(bombDroppedNow
+                ? $"[Pro-Imitator-DBG] BOMB_DROPPED at ({droppedBombPos!.X:F0},{droppedBombPos.Y:F0},{droppedBombPos.Z:F0}) — CT in range will hold harder"
+                : "[Pro-Imitator-DBG] BOMB no longer dropped (picked up, planted, or round reset)");
+            _logBombWasDropped = bombDroppedNow;
+        }
+
         foreach (var player in Utilities.FindAllEntitiesByDesignerName<CCSPlayerController>("cs_player_controller"))
         {
             if (!player.IsValid || !player.IsBot) continue;
@@ -421,7 +476,7 @@ public class ProImitator : BasePlugin
             // Weapon name is needed by a couple of traits. Cheap to read once.
             string? activeWeapon = pawn.WeaponServices?.ActiveWeapon?.Value?.DesignerName;
 
-            ApplyPersonality(player, bot, pawn, prof, now, activeWeapon);
+            ApplyPersonality(player, bot, pawn, prof, now, activeWeapon, droppedBombPos);
         }
     }
     // -------------------------------------------------------------------------
@@ -430,7 +485,7 @@ public class ProImitator : BasePlugin
     // Each block is opt-in; profiles can mix-and-match. Anything not listed in
     // a profile is left untouched (BotState's generic improvements still apply).
     // -------------------------------------------------------------------------
-    private void ApplyPersonality(CCSPlayerController player, CCSBot bot, CCSPlayerPawn pawn, ProProfile prof, float now, string? activeWeapon)
+    private void ApplyPersonality(CCSPlayerController player, CCSBot bot, CCSPlayerPawn pawn, ProProfile prof, float now, string? activeWeapon, Vector? droppedBombPos)
     {
         if (prof.AlwaysRushing)
         {
@@ -668,8 +723,27 @@ public class ProImitator : BasePlugin
                 // the defender behaviour gets overwritten and the Entry-
                 // tagged CT just rushes mid as if they were still on T.
                 // SafeTime alone is not enough to override that.
+                float defenderSafeTime = 6.0f;
+
+                // V4.5 dropped-bomb defence: if the bomb is on the ground
+                // (carrier died pre-plant) and this CT can guard it (within
+                // 1500u), bump SafeTime higher so they hold the bomb area
+                // harder. Denies T pickup attempts and forces Ts to clear
+                // the immediate bomb perimeter, not just any CT angle.
+                if (isCT && droppedBombPos != null && pawn.AbsOrigin != null)
+                {
+                    float dx = pawn.AbsOrigin.X - droppedBombPos.X;
+                    float dy = pawn.AbsOrigin.Y - droppedBombPos.Y;
+                    float dz = pawn.AbsOrigin.Z - droppedBombPos.Z;
+                    float distSq = dx * dx + dy * dy + dz * dz;
+                    if (distSq < 1500f * 1500f)
+                    {
+                        defenderSafeTime = 9.0f;  // stronger hold around the bomb
+                    }
+                }
+
                 ref float safeTime = ref bot.SafeTime;
-                safeTime           = 6.0f;
+                safeTime           = defenderSafeTime;
 
                 CountdownTimer hurry = bot.HurryTimer;
 
@@ -696,7 +770,25 @@ public class ProImitator : BasePlugin
             // IsWaitingBehindFriend cleared) stay REMOVED — those wiped
             // away the "strategic" behaviour the user wants the carrier
             // to keep.
-            if (isT && !_bombPlanted && IsCarryingBomb(pawn))
+            bool isCarrier = isT && !_bombPlanted && IsCarryingBomb(pawn);
+
+            // Edge-logged carrier detection (state change only).
+            if (_debugLog)
+            {
+                bool wasCarrier = _logWasCarrier.GetValueOrDefault(player.Slot, false);
+                if (isCarrier && !wasCarrier)
+                {
+                    Console.WriteLine($"[Pro-Imitator-DBG] CARRIER slot={player.Slot} bot={player.PlayerName} (BombFocus extra applied)");
+                    _logWasCarrier[player.Slot] = true;
+                }
+                else if (!isCarrier && wasCarrier)
+                {
+                    Console.WriteLine($"[Pro-Imitator-DBG] CARRIER no longer slot={player.Slot} bot={player.PlayerName}");
+                    _logWasCarrier[player.Slot] = false;
+                }
+            }
+
+            if (isCarrier)
             {
                 CountdownTimer hurry = bot.HurryTimer;
 
@@ -795,6 +887,22 @@ public class ProImitator : BasePlugin
         }
         bool forceKnife = inKnifeRush && !inDuel;
 
+        // Edge-detected log: knife force START / END (only when state flips).
+        if (_debugLog)
+        {
+            bool wasActive = _logKnifeForceWasActive.GetValueOrDefault(player.Slot, false);
+            if (forceKnife && !wasActive)
+            {
+                Console.WriteLine($"[Pro-Imitator-DBG] KNIFE_FORCE START slot={player.Slot} bot={player.PlayerName} (active={activeWeapon ?? "null"})");
+                _logKnifeForceWasActive[player.Slot] = true;
+            }
+            else if (!forceKnife && wasActive)
+            {
+                Console.WriteLine($"[Pro-Imitator-DBG] KNIFE_FORCE END slot={player.Slot} bot={player.PlayerName} (active={activeWeapon ?? "null"})");
+                _logKnifeForceWasActive[player.Slot] = false;
+            }
+        }
+
         if (forceKnife)
         {
             bool holdingKnife = activeWeapon != null && activeWeapon.StartsWith("weapon_knife");
@@ -869,6 +977,34 @@ public class ProImitator : BasePlugin
                 }
             }
         }
+    }
+    // -------------------------------------------------------------------------
+    // V4.5 — Find the dropped bomb's world position, or null if no bomb is
+    // currently dropped (carried, planted, or absent). A "dropped" C4 is a
+    // weapon_c4 entity whose OwnerEntity is invalid or null — the carrier
+    // either died or willingly dropped it. Excludes planted bombs (those
+    // become CPlantedC4 with a different designer name and stop being
+    // pickable).
+    //
+    // Used by BombFocus to make CTs near the dropped bomb hold harder
+    // (extra-defensive SafeTime), so they deny T pickup attempts.
+    //
+    // Caller responsibility: cache the result per-tick to avoid running
+    // FindAllEntitiesByDesignerName once per profiled bot per tick.
+    // -------------------------------------------------------------------------
+    private static Vector? FindDroppedBombPosition()
+    {
+        foreach (var bomb in Utilities.FindAllEntitiesByDesignerName<CC4>("weapon_c4"))
+        {
+            if (bomb == null || !bomb.IsValid) continue;
+
+            // OwnerEntity null/invalid = dropped (no carrier).
+            var owner = bomb.OwnerEntity?.Value;
+            if (owner != null && owner.IsValid) continue;
+
+            return bomb.AbsOrigin;
+        }
+        return null;
     }
     // -------------------------------------------------------------------------
     // Does the bot's inventory contain the C4? Used by BombFocus to give the
@@ -1026,6 +1162,23 @@ public class ProImitator : BasePlugin
         }
 
         cmd.ReplyToCommand($"[Pro-Imitator] reloaded: {_profiles.Count} profile(s) (was {oldCount}), re-evaluated {_assigned.Count} bot(s)");
+    }
+    // -------------------------------------------------------------------------
+    // Toggle the V4.5 debug logger. Off by default — keeps the server console
+    // clean for normal play. Turn it on when investigating "is feature X
+    // actually running?" — the logs cover round lifecycle events, knife rush
+    // edges, carrier detection, BombFocus phase transitions, dropped-bomb
+    // defence triggers. See the _debugLog field comment for what each log
+    // line means.
+    // -------------------------------------------------------------------------
+    public void OnProDebugCmd(CCSPlayerController? caller, CommandInfo cmd)
+    {
+        _debugLog = !_debugLog;
+        cmd.ReplyToCommand($"[Pro-Imitator] debug logging {(_debugLog ? "ON" : "OFF")}");
+        if (_debugLog)
+        {
+            Console.WriteLine("[Pro-Imitator-DBG] enabled. Round lifecycle + per-bot state changes will log to this console.");
+        }
     }
 }
 // -----------------------------------------------------------------------------

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -275,15 +275,9 @@ public class ProImitator : BasePlugin
             if (!kvp.Value.KnifeRush) continue;
             _knifeRushUntil[kvp.Key] = now + kvp.Value.KnifeRushSec;
             knifeRushCount++;
-            if (_debugLog)
-            {
-                Console.WriteLine($"[Pro-Imitator-DBG] knife rush window opened slot={kvp.Key} profile={kvp.Value.Name} until=+{kvp.Value.KnifeRushSec:F1}s");
-            }
+            DebugBroadcast($"knife rush opened slot={kvp.Key} {kvp.Value.Name} +{kvp.Value.KnifeRushSec:F1}s");
         }
-        if (_debugLog)
-        {
-            Console.WriteLine($"[Pro-Imitator-DBG] OnRoundFreezeEnd: {_assigned.Count} profiled, {knifeRushCount} got knife rush windows");
-        }
+        DebugBroadcast($"OnRoundFreezeEnd: {_assigned.Count} profiled, {knifeRushCount} knife rush windows");
         return HookResult.Continue;
     }
     // -------------------------------------------------------------------------
@@ -315,10 +309,7 @@ public class ProImitator : BasePlugin
         _bombPlanted        = false;
         _logBombWasDropped  = false;
 
-        if (_debugLog)
-        {
-            Console.WriteLine($"[Pro-Imitator-DBG] OnRoundStart fired. assigned={_assigned.Count} bots, _bombPlanted reset to false");
-        }
+        DebugBroadcast($"OnRoundStart, assigned={_assigned.Count}, _bombPlanted reset");
 
         if (_assigned.Count == 0) return HookResult.Continue;
 
@@ -335,10 +326,7 @@ public class ProImitator : BasePlugin
     public HookResult OnBombPlanted(EventBombPlanted @event, GameEventInfo info)
     {
         _bombPlanted = true;
-        if (_debugLog)
-        {
-            Console.WriteLine("[Pro-Imitator-DBG] OnBombPlanted fired → switching to post-plant role inversion (T defender, CT attacker)");
-        }
+        DebugBroadcast("OnBombPlanted → post-plant inversion (T=defender, CT=attacker)");
         return HookResult.Continue;
     }
     // -------------------------------------------------------------------------
@@ -451,11 +439,11 @@ public class ProImitator : BasePlugin
         // Edge-log when state transitions for debug visibility.
         Vector? droppedBombPos = _bombPlanted ? null : FindDroppedBombPosition();
         bool bombDroppedNow = droppedBombPos != null;
-        if (_debugLog && bombDroppedNow != _logBombWasDropped)
+        if (bombDroppedNow != _logBombWasDropped)
         {
-            Console.WriteLine(bombDroppedNow
-                ? $"[Pro-Imitator-DBG] BOMB_DROPPED at ({droppedBombPos!.X:F0},{droppedBombPos.Y:F0},{droppedBombPos.Z:F0}) — CT in range will hold harder"
-                : "[Pro-Imitator-DBG] BOMB no longer dropped (picked up, planted, or round reset)");
+            DebugBroadcast(bombDroppedNow
+                ? $"BOMB_DROPPED at ({droppedBombPos!.X:F0},{droppedBombPos.Y:F0}) — CT within 1500u hold harder"
+                : "BOMB no longer dropped (picked up / planted / round reset)");
             _logBombWasDropped = bombDroppedNow;
         }
 
@@ -773,17 +761,16 @@ public class ProImitator : BasePlugin
             bool isCarrier = isT && !_bombPlanted && IsCarryingBomb(pawn);
 
             // Edge-logged carrier detection (state change only).
-            if (_debugLog)
             {
                 bool wasCarrier = _logWasCarrier.GetValueOrDefault(player.Slot, false);
                 if (isCarrier && !wasCarrier)
                 {
-                    Console.WriteLine($"[Pro-Imitator-DBG] CARRIER slot={player.Slot} bot={player.PlayerName} (BombFocus extra applied)");
+                    DebugBroadcast($"CARRIER {player.PlayerName} (slot={player.Slot})");
                     _logWasCarrier[player.Slot] = true;
                 }
                 else if (!isCarrier && wasCarrier)
                 {
-                    Console.WriteLine($"[Pro-Imitator-DBG] CARRIER no longer slot={player.Slot} bot={player.PlayerName}");
+                    DebugBroadcast($"CARRIER no longer {player.PlayerName}");
                     _logWasCarrier[player.Slot] = false;
                 }
             }
@@ -888,17 +875,16 @@ public class ProImitator : BasePlugin
         bool forceKnife = inKnifeRush && !inDuel;
 
         // Edge-detected log: knife force START / END (only when state flips).
-        if (_debugLog)
         {
             bool wasActive = _logKnifeForceWasActive.GetValueOrDefault(player.Slot, false);
             if (forceKnife && !wasActive)
             {
-                Console.WriteLine($"[Pro-Imitator-DBG] KNIFE_FORCE START slot={player.Slot} bot={player.PlayerName} (active={activeWeapon ?? "null"})");
+                DebugBroadcast($"KNIFE_FORCE START {player.PlayerName} (active={activeWeapon ?? "null"})");
                 _logKnifeForceWasActive[player.Slot] = true;
             }
             else if (!forceKnife && wasActive)
             {
-                Console.WriteLine($"[Pro-Imitator-DBG] KNIFE_FORCE END slot={player.Slot} bot={player.PlayerName} (active={activeWeapon ?? "null"})");
+                DebugBroadcast($"KNIFE_FORCE END {player.PlayerName} (active={activeWeapon ?? "null"})");
                 _logKnifeForceWasActive[player.Slot] = false;
             }
         }
@@ -908,26 +894,18 @@ public class ProImitator : BasePlugin
             bool holdingKnife = activeWeapon != null && activeWeapon.StartsWith("weapon_knife");
             if (!holdingKnife)
             {
-                // V4.1 — we now fire BOTH command paths every tick because
-                // playtests showed the client-only `slot3` was getting
-                // consistently outraced by the bot AI's internal weapon
-                // selection (which runs every server tick too).
-                //
-                //   1. `slot3`        — client-side slot selection. Cheap,
-                //                       maps to whatever knife the bot has.
-                //   2. `use weapon_knife` via Server.ExecuteCommand —
-                //                       server-side path through the engine's
-                //                       weapon-use logic. Different priority
-                //                       than slot3 in the command queue, so
-                //                       at least one of the two should win
-                //                       the race against the AI's auto-select
-                //                       on any given tick.
+                // V4.6 — `bot_command` does not exist in CS2 (verified by
+                // "Unknown command: bot_command" log spam in playtests). The
+                // dual-path V4.1 trick is gone; we keep only `slot3`. If the
+                // bot AI continues to outrace `slot3`, the next escalation
+                // would be a direct schema write to
+                // pawn.WeaponServices.ActiveWeapon (not implemented yet —
+                // brittle without confirmed schema-field semantics in CSS).
                 //
                 // No cooldown: re-issue every tick until activeWeapon
                 // actually becomes a knife. Once holdingKnife=true the loop
                 // stops issuing.
                 NativeAPI.IssueClientCommand((int)player.Slot, "slot3");
-                Server.ExecuteCommand($"bot_command \"{player.PlayerName}\" use weapon_knife");
             }
         }
 
@@ -1177,8 +1155,25 @@ public class ProImitator : BasePlugin
         cmd.ReplyToCommand($"[Pro-Imitator] debug logging {(_debugLog ? "ON" : "OFF")}");
         if (_debugLog)
         {
-            Console.WriteLine("[Pro-Imitator-DBG] enabled. Round lifecycle + per-bot state changes will log to this console.");
+            // Broadcast on toggle-on so all players see we just enabled debug.
+            // Subsequent logs go via DebugBroadcast which also broadcasts.
+            Server.PrintToChatAll($" \x04[ProDBG]\x01 logging enabled — events will appear here");
         }
+    }
+    // -------------------------------------------------------------------------
+    // V4.6 — Centralised debug print. Goes to BOTH the server console
+    // (Console.WriteLine, useful when running headless / via PowerShell)
+    // AND the in-game chat (PrintToChatAll, the only place a listen-server
+    // host can actually see plugin output). Gated by _debugLog so it's
+    // silent when debug isn't on.
+    //
+    // Format: green prefix "[ProDBG]" + message in default colour.
+    // -------------------------------------------------------------------------
+    private void DebugBroadcast(string msg)
+    {
+        if (!_debugLog) return;
+        Console.WriteLine($"[Pro-Imitator-DBG] {msg}");
+        Server.PrintToChatAll($" \x04[ProDBG]\x01 {msg}");
     }
 }
 // -----------------------------------------------------------------------------

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -101,7 +101,6 @@ public class ProImitator : BasePlugin
 
         RegisterEventHandler<EventPlayerSpawn>(OnPlayerSpawn);
         RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam);
-        RegisterEventHandler<EventRoundStart>(OnRoundStart);
         RegisterListener<Listeners.OnTick>(OnTick);
 
         // Register commands as plain game console commands (mirrors how the
@@ -198,196 +197,6 @@ public class ProImitator : BasePlugin
         }
 
         return HookResult.Continue;
-    }
-    // -------------------------------------------------------------------------
-    // Role-bias the bot's primary weapon, per round. All-or-save rule.
-    //
-    // Design philosophy: NO hardcoded "you need X$ to buy a rifle" floors.
-    // The engine + BotBuy already decide eco / semi-buy / full-buy each round
-    // based on the bot's account and team state. ProImitator just OBSERVES
-    // what they decided and either:
-    //   - swaps the wrong primary to the role's preferred (if affordable), or
-    //   - refunds the wrong primary so the bot can save for next round.
-    //
-    // Why "all-or-save" instead of "keep what you have": the half-buy funnel.
-    // Without the save branch, an AWPer who got a Scout from BotBuy can never
-    // afford the Scout->AWP upgrade, keeps the Scout, gets killed, buys
-    // another Scout next round, and never reaches AWP money. The refund
-    // breaks the funnel: the bot ends the round pistol-only but with
-    // accumulated cash for a real full-buy.
-    //
-    // See TrySwapToPreferredPrimary's comment block for the case-by-case
-    // breakdown.
-    //
-    // Why a separate hook instead of OnTick: refunding / GiveNamedItem is
-    // only legal during freeze, and we don't want to fight BotBuy's armor-
-    // gift / drop-weapon cycles that fire in the early freeze. We delay 3.5s
-    // after EventRoundStart so BotBuy's longest timer (3.0s) has settled;
-    // freeze is typically 15-20s, so we're well inside the buy window.
-    // -------------------------------------------------------------------------
-    [GameEventHandler]
-    public HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
-    {
-        if (_assigned.Count == 0) return HookResult.Continue;
-
-        AddTimer(3.5f, SwapPreferredPrimaries);
-        return HookResult.Continue;
-    }
-    // -------------------------------------------------------------------------
-    private void SwapPreferredPrimaries()
-    {
-        foreach (var kvp in _assigned)
-        {
-            var player = Utilities.GetPlayerFromSlot(kvp.Key);
-            if (player == null || !player.IsValid || !player.IsBot) continue;
-            if (player.InGameMoneyServices == null) continue;
-
-            var pawn = player.PlayerPawn.Value;
-            if (pawn == null || !pawn.IsValid) continue;
-
-            var prof = kvp.Value;
-            bool isT = player.Team == CsTeam.Terrorist;
-            bool isCT = player.Team == CsTeam.CounterTerrorist;
-            if (!isT && !isCT) continue;
-
-            // Rifler / AWPer should be mutually exclusive (template warns); if
-            // both true Rifler wins by reading first.
-            if (prof.Rifler)
-            {
-                // Prices mirror BotBuy.cs price table (AK 2700, M4A1 2900).
-                string preferred = isT ? "weapon_ak47" : "weapon_m4a1";
-                int     price     = isT ? 2700        : 2900;
-                TrySwapToPreferredPrimary(player, pawn, preferred, price);
-            }
-            else if (prof.AWPer)
-            {
-                TrySwapToPreferredPrimary(player, pawn, "weapon_awp", 4750);
-            }
-        }
-    }
-    // -------------------------------------------------------------------------
-    // The all-or-save rule: a role-buy activates "if possible", otherwise
-    // the bot refunds whatever wrong primary they got and saves for next
-    // round. Three cases, depending on what the engine + BotBuy gave them:
-    //
-    //   1. Bot has no big-primary (only pistol / SMG / shotgun / nothing).
-    //      The engine read the round as eco / semi-buy — we leave it alone.
-    //      The role doesn't override CS's economy model when the bot truly
-    //      has no rifle money.
-    //
-    //   2. Bot has a big-primary AND can afford the swap to the preferred
-    //      weapon (netCost = preferredPrice - ownedPrice, possibly negative).
-    //      We refund the wrong primary, give the preferred, adjust the
-    //      account by netCost. Examples:
-    //        - AK 2700 -> Krieg 3000:        +300  small upgrade fee
-    //        - AUG 3300 -> M4 2900:          -400  bot gets a refund
-    //        - Galil 1800 -> AK 2700:        +900  if affordable
-    //        - M4 2900 -> AWP 4750 (AWPer): +1850
-    //
-    //   3. Bot has a big-primary but CAN'T afford the swap. Without this
-    //      branch, ZywOo on a force-buy round ends up holding the Scout the
-    //      engine bought him because the AWP upgrade costs more than he has.
-    //      Next round he buys another Scout (1700$ down the drain), never
-    //      reaches the 4750$ AWP threshold. Funnel of doom.
-    //
-    //      Fix: refund the wrong primary and let the bot save. He ends the
-    //      round with pistol only but +ownedPrice$ in the bank — a real save
-    //      round in pro terms.
-    //
-    // Carry-over caveat: if the bot survived last round with weapon W and
-    // we hit case 3, we refund W and credit ownedPrice$ — money the bot
-    // didn't actually spend this round. Bounded exploit (≤ 5000$ per swap,
-    // typically ≤ 1800$ for the Galil case), matches how BotBuy.Refund
-    // works in the same scenarios.
-    // -------------------------------------------------------------------------
-    private static void TrySwapToPreferredPrimary(
-        CCSPlayerController player,
-        CCSPlayerPawn pawn,
-        string preferred,
-        int preferredPrice)
-    {
-        // Already holds the preferred weapon? Done.
-        if (HasWeapon(pawn, preferred)) return;
-
-        // Find any rifle OR sniper currently owned. SMGs / shotguns / pistols
-        // do NOT count — those mean the engine + BotBuy decided "eco / semi-
-        // buy round, no rifle money this round". We respect that.
-        (string? ownedName, int ownedPrice) = FindOwnedBigPrimary(pawn);
-        if (ownedName == null) return;
-
-        int  netCost   = preferredPrice - ownedPrice;
-        bool canAfford = netCost <= 0
-                      || player.InGameMoneyServices!.Account >= netCost;
-
-        if (canAfford)
-        {
-            // Swap: refund the wrong primary, give the preferred, pay the diff.
-            player.RemoveItemByDesignerName(ownedName);
-            player.GiveNamedItem(preferred);
-            player.InGameMoneyServices!.Account -= netCost;  // negative = refund
-        }
-        else
-        {
-            // Can't afford the role weapon. Refund the wrong primary and let
-            // the bot save. Keeps the role identity coherent ("ZywOo doesn't
-            // half-buy Scout") and stops the per-round eco bleed.
-            player.RemoveItemByDesignerName(ownedName);
-            player.InGameMoneyServices!.Account += ownedPrice;
-        }
-        Utilities.SetStateChanged(player, "CCSPlayerController", "m_pInGameMoneyServices");
-    }
-    // -------------------------------------------------------------------------
-    // Scan the bot's inventory for the first owned rifle / sniper and return
-    // its designer name + BotBuy-canonical price. Returns (null, 0) if the
-    // bot only has SMGs / shotguns / pistols.
-    //
-    // Price table mirrors BotBuy.cs — keep in sync if upstream ever changes.
-    // -------------------------------------------------------------------------
-    private static readonly Dictionary<string, int> BigPrimaryPrices = new(StringComparer.OrdinalIgnoreCase)
-    {
-        // Rifles
-        { "weapon_ak47",            2700 },
-        { "weapon_m4a1",            2900 },
-        { "weapon_m4a1_silencer",   2900 },
-        { "weapon_sg556",           3000 },
-        { "weapon_aug",             3300 },
-        { "weapon_galilar",         1800 },
-        { "weapon_famas",           1950 },
-        // Snipers
-        { "weapon_awp",             4750 },
-        { "weapon_ssg08",           1700 },
-        { "weapon_scar20",          5000 },
-        { "weapon_g3sg1",           5000 },
-    };
-
-    private static (string? name, int price) FindOwnedBigPrimary(CCSPlayerPawn pawn)
-    {
-        var weapons = pawn.WeaponServices?.MyWeapons;
-        if (weapons == null) return (null, 0);
-
-        foreach (var handle in weapons)
-        {
-            var w = handle.Value;
-            if (w == null || !w.IsValid) continue;
-
-            string? n = w.DesignerName;
-            if (n != null && BigPrimaryPrices.TryGetValue(n, out int p))
-                return (n, p);
-        }
-        return (null, 0);
-    }
-    // -------------------------------------------------------------------------
-    private static bool HasWeapon(CCSPlayerPawn pawn, string designerName)
-    {
-        var weapons = pawn.WeaponServices?.MyWeapons;
-        if (weapons == null) return false;
-
-        foreach (var handle in weapons)
-        {
-            var w = handle.Value;
-            if (w != null && w.IsValid && w.DesignerName == designerName) return true;
-        }
-        return false;
     }
     // -------------------------------------------------------------------------
     private ProProfile? MatchProfile(string botName)
@@ -618,18 +427,17 @@ public class ProImitator : BasePlugin
 
         if (prof.Rifler)
         {
-            // Switch-back half of the Rifler trait. The eco-aware *buy* half
-            // runs in OnRoundFreezeEnded (post round-start, once per round);
-            // here we just keep the bot on its rifle if it picks up a pistol
-            // off the ground or drops to a knife after running out of ammo.
+            // Pure preference: if the bot has a rifle in inventory but is
+            // currently holding something else (pistol from auto-switch on
+            // empty mag, knife, etc), issue `use weapon_<rifle>` to switch
+            // back.
             //
-            // GiveNamedItem is NOT called here — see the per-round buy logic
-            // for that. We issue `use weapon_<name>` which only succeeds if
-            // the weapon is already in inventory, so we never duplicate a
-            // rifle or give one for free.
+            // We never call GiveNamedItem and never touch Account — the
+            // engine + BotBuy fully decide what the bot owns. `use weapon_*`
+            // only succeeds if the weapon is already in inventory.
             //
-            // A 0.5s cooldown prevents spamming the engine: the swap takes a
-            // few ticks to resolve, and the next tick after we issue would
+            // A 0.5s cooldown prevents spamming the engine: the swap takes
+            // a few ticks to resolve, and the next tick after we issue would
             // still see the old activeWeapon.
             bool holdingRifle = activeWeapon != null && RifleDesignerNames.Contains(activeWeapon);
             if (!holdingRifle
@@ -648,9 +456,8 @@ public class ProImitator : BasePlugin
         if (prof.AWPer)
         {
             // AWPer mirror of the Rifler switch-back. Same cooldown, same
-            // no-give policy: the per-round buy of the AWP happens in
-            // OnRoundFreezeEnded; here we just prevent the bot from running
-            // around with a teammate's rifle once it has the AWP available.
+            // no-give policy: if the engine ever gave the bot an AWP / SSG08
+            // and they're holding something else, switch back to it.
             bool holdingSniper = activeWeapon != null && SniperDesignerNames.Contains(activeWeapon);
             if (!holdingSniper
                 && (!_lastWeaponSwitchAt.TryGetValue(player.Slot, out float lastAt)
@@ -818,20 +625,16 @@ public sealed class ProProfile
     public bool NeverWaitsBetweenShots { get; set; } = false;
     public bool NoApproachPause      { get; set; } = false;
 
-    // "I main rifles." Two effects, both deferring eco-vs-buy decisions to
-    // the engine + BotBuy:
-    //   1. At round-freeze, if the bot was given ANY rifle/sniper by the
-    //      engine, swap it for the role's main rifle (AK for T, M4 for CT)
-    //      and pay only the price difference. If they only got a pistol /
-    //      SMG / shotgun, leave it (= the round is eco/semi-buy per the
-    //      engine's read, we don't override that).
-    //   2. Per tick, if the bot is holding a non-rifle but already owns one,
-    //      `use weapon_*` switches them back to it.
+    // "I main rifles." Pure preference — we do not buy, give, refund or
+    // touch the bot's account. Every tick, if the bot is currently holding
+    // a non-rifle but already owns one in inventory, `use weapon_*` switches
+    // them back. The engine + BotBuy fully decide what weapon the bot owns;
+    // we only steer the active slot among what they already have.
     public bool Rifler               { get; set; } = false;
 
-    // AWPer mirror of Rifler. Same swap-not-buy logic: if the bot got a
-    // primary, swap it to AWP (paying the diff); if they only got a small
-    // primary or nothing, leave it. Same per-tick switch-back behavior.
+    // AWPer mirror of Rifler. Same pure-preference logic: if the bot owns
+    // an AWP / SSG08 in inventory, switch to it. If the engine never gave
+    // them a sniper this round, they play whatever they have.
     public bool AWPer                { get; set; } = false;
 
     // Counter-strafe at engagement onset, gated by probability so the bot

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -246,16 +246,25 @@ public class ProImitator : BasePlugin
             // first — keeps behavior deterministic for misconfigured profiles.
             if (prof.Rifler)
             {
+                // Prices mirror BotBuy.cs price table (AK 2700, M4A1 2900).
                 string preferred = isT ? "weapon_ak47" : "weapon_m4a1";
                 int     price     = isT ? 2700        : 2900;
-                int     fullBuy   = price + 1000;     // + kevlar+helm floor
 
-                TryBuyRolePrimary(player, pawn, preferred, price, fullBuy, FindOwnedRifle);
+                // Full-buy floor = rifle + armor + min nade kit. A pro full-buy
+                // is roughly rifle (2700-2900) + armor (1000) + 1-2 nades
+                // (smoke 300, flash 200, molly/HE 300-500) -> ~4700-5100. We
+                // pick 5000 as a round number that's strict enough that
+                // tagging a "Rifler" never triggers a half-buy panic-rifle
+                // on a 3500$ account.
+                TryBuyRolePrimary(player, pawn, preferred, price, 5000, FindOwnedRifle);
             }
             else if (prof.AWPer)
             {
-                // AWP costs 4750; full-buy floor 5750.
-                TryBuyRolePrimary(player, pawn, "weapon_awp", 4750, 5750, FindOwnedSniper);
+                // AWP 4750 + armor 1000 + nades + pistol upgrade ≈ 6500. The
+                // floor is high on purpose: a pro who can't afford the full
+                // AWP kit shouldn't get a "naked AWP" buy that leaves them
+                // with no utility and a bad pistol.
+                TryBuyRolePrimary(player, pawn, "weapon_awp", 4750, 6500, FindOwnedSniper);
             }
         }
     }

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -1,0 +1,384 @@
+using System.Text.Json;
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Attributes.Registration;
+using CounterStrikeSharp.API.Modules.Commands;
+using CounterStrikeSharp.API.Modules.Memory;
+using CounterStrikeSharp.API.Modules.Utils;
+
+namespace ProImitator;
+
+// -----------------------------------------------------------------------------
+// ProImitator
+//
+// Layered-on-top personality plugin: scans bot spawn events, matches the bot's
+// PlayerName against one of the JSON profiles shipped in `profiles/`, and on
+// each tick writes a small set of bot-AI properties that reflect the matched
+// pro's playstyle (e.g. always-rushing, never-sneaks, no-panic).
+//
+// Why "layered on top": this plugin does NOT replace anything in the suite. It
+// only sets properties that are either un-touched by BotState or that BotState
+// also sets — in which case both writes agree (e.g. PanicTimer = 0). We never
+// fight another plugin's intent; we just amplify or specialise it per-bot.
+//
+// Intentionally minimal V1 scope:
+//   - No memory patches  (that's BotAI's domain)
+//   - No native hooks    (that's BotAimImprover's domain)
+//   - No per-bot aim style override (would require coupling with BotAimImprover)
+//   - No pathing / waypoints (we leave CS2's nav-mesh + BotState in charge)
+//
+// Profile location (read at plugin Load):
+//   addons/counterstrikesharp/plugins/ProImitator/profiles/*.json
+//
+// Identity model:
+//   - Bots are spawned via `bot_add_ct "<name>"` (see Commands.txt rosters).
+//   - We key everything on `player.Slot` so a single bot keeps its profile for
+//     its whole lifetime, even across deaths / respawns within the round.
+// -----------------------------------------------------------------------------
+public class ProImitator : BasePlugin
+{
+    public override string ModuleName        => "Pro-Imitator";
+    public override string ModuleVersion     => "0.1.0";
+    public override string ModuleAuthor      => "Contribution to ed0ard/CS2-Bot-Improver";
+    public override string ModuleDescription => "Per-bot personality presets so the donk bot plays like donk";
+
+    // Loaded profiles, keyed by their JSON 'Name' (lowercased) for de-dup.
+    private readonly Dictionary<string, ProProfile> _profiles = new();
+
+    // Bot slot -> applied profile. Survives multiple spawns; cleared on team
+    // change so a bot moved to spectator drops its personality cleanly.
+    private readonly Dictionary<int, ProProfile> _assigned = new();
+
+    // -------------------------------------------------------------------------
+    public override void Load(bool hotReload)
+    {
+        LoadProfilesFromDisk();
+
+        RegisterEventHandler<EventPlayerSpawn>(OnPlayerSpawn);
+        RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam);
+        RegisterListener<Listeners.OnTick>(OnTick);
+
+        Console.WriteLine($"[Pro-Imitator] loaded with {_profiles.Count} profile(s): "
+                          + string.Join(", ", _profiles.Values.Select(p => p.Name)));
+    }
+    // -------------------------------------------------------------------------
+    private void LoadProfilesFromDisk()
+    {
+        _profiles.Clear();
+
+        string dir = Path.Combine(ModuleDirectory, "profiles");
+        if (!Directory.Exists(dir))
+        {
+            Console.WriteLine($"[Pro-Imitator] profiles dir not found: {dir}");
+            return;
+        }
+
+        var opts = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+        };
+
+        foreach (string path in Directory.EnumerateFiles(dir, "*.json"))
+        {
+            string filename = Path.GetFileName(path);
+            // Profiles starting with '_' are templates/examples; skip silently.
+            if (filename.StartsWith('_')) continue;
+
+            try
+            {
+                string json = File.ReadAllText(path);
+                var prof = JsonSerializer.Deserialize<ProProfile>(json, opts);
+                if (prof == null || string.IsNullOrWhiteSpace(prof.Name))
+                {
+                    Console.WriteLine($"[Pro-Imitator] skip {filename}: missing Name");
+                    continue;
+                }
+                _profiles[prof.Name.ToLowerInvariant()] = prof;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Pro-Imitator] failed to parse {filename}: {ex.Message}");
+            }
+        }
+    }
+    // -------------------------------------------------------------------------
+    // Spawn / team transitions decide who gets a profile attached.
+    // -------------------------------------------------------------------------
+    [GameEventHandler]
+    public HookResult OnPlayerSpawn(EventPlayerSpawn @event, GameEventInfo info)
+    {
+        var player = @event.Userid;
+        if (player == null || !player.IsValid || !player.IsBot) return HookResult.Continue;
+
+        // First spawn for this slot? Attempt to match. Subsequent respawns keep
+        // the same profile (we never re-evaluate mid-match unless team changes).
+        if (_assigned.ContainsKey(player.Slot)) return HookResult.Continue;
+
+        var prof = MatchProfile(player.PlayerName);
+        if (prof != null)
+        {
+            _assigned[player.Slot] = prof;
+            Console.WriteLine($"[Pro-Imitator] attached profile '{prof.Name}' to bot '{player.PlayerName}' (slot {player.Slot})");
+        }
+
+        return HookResult.Continue;
+    }
+    // -------------------------------------------------------------------------
+    [GameEventHandler]
+    public HookResult OnPlayerTeam(EventPlayerTeam @event, GameEventInfo info)
+    {
+        var player = @event.Userid;
+        if (player == null || !player.IsValid) return HookResult.Continue;
+
+        // Spectator / unassigned: drop the profile so re-joining as a bot lets
+        // us re-evaluate (the controller's PlayerName might be reused).
+        if ((CsTeam)@event.Team != CsTeam.CounterTerrorist
+            && (CsTeam)@event.Team != CsTeam.Terrorist)
+        {
+            _assigned.Remove(player.Slot);
+        }
+
+        return HookResult.Continue;
+    }
+    // -------------------------------------------------------------------------
+    private ProProfile? MatchProfile(string botName)
+    {
+        if (string.IsNullOrEmpty(botName)) return null;
+        string lower = botName.ToLowerInvariant();
+
+        foreach (var prof in _profiles.Values)
+        {
+            foreach (string candidate in prof.MatchByName)
+            {
+                if (candidate.Equals(lower, StringComparison.OrdinalIgnoreCase))
+                    return prof;
+            }
+        }
+        return null;
+    }
+    // -------------------------------------------------------------------------
+    // Per-tick personality writes. Kept fast: a small dictionary lookup per
+    // bot and a handful of ref-property writes when a profile is attached.
+    //
+    // Note on ordering: CounterStrikeSharp runs plugin tick listeners in load
+    // order. Plugins loaded later get the last word. We don't depend on that
+    // here — we only set values that BotState either leaves alone (HurryTimer,
+    // SneakTimer, SafeTime) or sets to the same value we'd want (PanicTimer=0).
+    // -------------------------------------------------------------------------
+    private void OnTick()
+    {
+        if (_assigned.Count == 0) return;
+
+        float now = Server.CurrentTime;
+
+        foreach (var player in Utilities.FindAllEntitiesByDesignerName<CCSPlayerController>("cs_player_controller"))
+        {
+            if (!player.IsValid || !player.IsBot) continue;
+            if (!_assigned.TryGetValue(player.Slot, out var prof)) continue;
+
+            // Don't override anything when a human has taken over the bot.
+            if (player.HasBeenControlledByPlayerThisRound) continue;
+
+            var pawn = player.PlayerPawn.Value;
+            if (pawn == null || !pawn.IsValid) continue;
+
+            var bot = pawn.Bot;
+            if (bot == null) continue;
+
+            ApplyPersonality(bot, prof, now);
+        }
+    }
+    // -------------------------------------------------------------------------
+    // The core: translate a profile's boolean traits into CCSBot property writes.
+    //
+    // Each block is opt-in; profiles can mix-and-match. Anything not listed in
+    // a profile is left untouched (BotState's generic improvements still apply).
+    // -------------------------------------------------------------------------
+    private static void ApplyPersonality(CCSBot bot, ProProfile prof, float now)
+    {
+        if (prof.AlwaysRushing)
+        {
+            // HurryTimer drives bot "I'm in a hurry to reach my goal" behavior:
+            // ignores hiding spots, takes shortest paths, less likely to camp.
+            CountdownTimer hurryTimer = bot.HurryTimer;
+
+            ref float duration = ref hurryTimer.Duration;
+            duration = 600.0f;
+
+            ref float timestamp = ref hurryTimer.Timestamp;
+            timestamp = now + 600.0f;
+
+            ref float timescale = ref hurryTimer.Timescale;
+            timescale = 1.0f;
+
+            // Reinforce: an aggressive entry never patiently walks. IsRunning
+            // is set to true by BotState on stuck/idle paths anyway, but here
+            // we make it the default while the bot has hurry intent.
+            ref bool isRunning = ref bot.IsRunning;
+            isRunning = true;
+        }
+
+        if (prof.NeverSneaks)
+        {
+            // SneakTimer = silent crouch-walk. Zero it so even cautious
+            // pathing code can't put us in sneak mode.
+            CountdownTimer sneakTimer = bot.SneakTimer;
+
+            ref float sneakDuration = ref sneakTimer.Duration;
+            sneakDuration = 0.0f;
+
+            ref float sneakTimestamp = ref sneakTimer.Timestamp;
+            sneakTimestamp = 0.0f;
+
+            ref float sneakTimescale = ref sneakTimer.Timescale;
+            sneakTimescale = 1.0f;
+        }
+
+        if (prof.NeverPolite)
+        {
+            // PoliteTimer = "I'm waiting for a teammate to pass". Disable for
+            // bots whose real-life counterpart pushes through their own team.
+            CountdownTimer politeTimer = bot.PoliteTimer;
+
+            ref float politeDuration = ref politeTimer.Duration;
+            politeDuration = 0.0f;
+
+            ref float politeTimestamp = ref politeTimer.Timestamp;
+            politeTimestamp = 0.0f;
+
+            ref float politeTimescale = ref politeTimer.Timescale;
+            politeTimescale = 1.0f;
+
+            ref bool waitingBehindFriend = ref bot.IsWaitingBehindFriend;
+            waitingBehindFriend = false;
+        }
+
+        if (prof.NoSafeTime)
+        {
+            // SafeTime = how long after spawn the bot considers the area safe
+            // and skips threat checks. BotState already zeroes this on spawn,
+            // but we keep writing it each tick so the bot never "feels safe".
+            ref float safeTime = ref bot.SafeTime;
+            safeTime = 0f;
+        }
+
+        if (prof.NoPanic)
+        {
+            // BotState already zeroes PanicTimer in its OnTick, but doing it
+            // ourselves means the personality survives if BotState is unloaded.
+            CountdownTimer panicTimer = bot.PanicTimer;
+
+            ref float panicDuration = ref panicTimer.Duration;
+            panicDuration = 0.0f;
+
+            ref float panicTimestamp = ref panicTimer.Timestamp;
+            panicTimestamp = 0.0f;
+
+            ref float panicTimescale = ref panicTimer.Timescale;
+            panicTimescale = 1.0f;
+        }
+    }
+    // -------------------------------------------------------------------------
+    // Console commands. Mirrors the convention used elsewhere in the suite:
+    // `css_*` prefix, [ConsoleCommand] + [CommandHelper] attributes, reply via
+    // CommandInfo so both server console and client console see the output.
+    // -------------------------------------------------------------------------
+    [ConsoleCommand("css_pro_list", "List Pro-Imitator profiles loaded from disk")]
+    [CommandHelper(minArgs: 0, usage: "", whoCanExecute: CommandUsage.CLIENT_AND_SERVER)]
+    public void OnProListCmd(CCSPlayerController? caller, CommandInfo cmd)
+    {
+        if (_profiles.Count == 0)
+        {
+            cmd.ReplyToCommand("[Pro-Imitator] no profiles loaded");
+            return;
+        }
+
+        cmd.ReplyToCommand($"[Pro-Imitator] {_profiles.Count} profile(s):");
+        foreach (var prof in _profiles.Values.OrderBy(p => p.Name))
+        {
+            string aliases = prof.MatchByName.Count > 0 ? string.Join(", ", prof.MatchByName) : "(none)";
+            cmd.ReplyToCommand($"  - {prof.Name}  matches: [{aliases}]");
+        }
+    }
+    // -------------------------------------------------------------------------
+    [ConsoleCommand("css_pro_assigned", "List bots that currently have a Pro-Imitator profile attached")]
+    [CommandHelper(minArgs: 0, usage: "", whoCanExecute: CommandUsage.CLIENT_AND_SERVER)]
+    public void OnProAssignedCmd(CCSPlayerController? caller, CommandInfo cmd)
+    {
+        if (_assigned.Count == 0)
+        {
+            cmd.ReplyToCommand("[Pro-Imitator] no bots currently profiled");
+            return;
+        }
+
+        // Build slot -> controller index once, so the per-assignment lookups
+        // below are O(1) instead of O(N*M) for verbose servers.
+        var bySlot = new Dictionary<int, string>();
+        foreach (var p in Utilities.GetPlayers())
+        {
+            if (p == null || !p.IsValid) continue;
+            bySlot[p.Slot] = p.PlayerName;
+        }
+
+        cmd.ReplyToCommand($"[Pro-Imitator] {_assigned.Count} bot(s) profiled:");
+        foreach (var kvp in _assigned)
+        {
+            string name = bySlot.TryGetValue(kvp.Key, out var n) ? n : "<gone>";
+            cmd.ReplyToCommand($"  slot {kvp.Key}  bot '{name}'  -> profile '{kvp.Value.Name}'");
+        }
+    }
+    // -------------------------------------------------------------------------
+    [ConsoleCommand("css_pro_reload", "Re-read JSON profiles from disk and re-evaluate all bots")]
+    [CommandHelper(minArgs: 0, usage: "", whoCanExecute: CommandUsage.CLIENT_AND_SERVER)]
+    public void OnProReloadCmd(CCSPlayerController? caller, CommandInfo cmd)
+    {
+        int oldCount = _profiles.Count;
+        LoadProfilesFromDisk();
+        _assigned.Clear();
+
+        // Re-evaluate every currently-alive bot against the freshly loaded set.
+        foreach (var p in Utilities.GetPlayers())
+        {
+            if (p == null || !p.IsValid || !p.IsBot) continue;
+            var prof = MatchProfile(p.PlayerName);
+            if (prof != null) _assigned[p.Slot] = prof;
+        }
+
+        cmd.ReplyToCommand($"[Pro-Imitator] reloaded: {_profiles.Count} profile(s) (was {oldCount}), re-evaluated {_assigned.Count} bot(s)");
+    }
+}
+// -----------------------------------------------------------------------------
+// ProProfile
+//
+// Bag of personality flags + identity. Mirrors the JSON shape on disk: see
+// `profiles/_template.json` for the documented field-by-field reference.
+//
+// Adding a new trait? Two steps:
+//   1. Add the property here (default to a no-op value).
+//   2. Add an `if (prof.NewTrait) { ... }` block in ProImitator.ApplyPersonality
+//      that translates it into CCSBot ref writes.
+// -----------------------------------------------------------------------------
+public sealed class ProProfile
+{
+    // Display name. Shown in logs and in `css_pro_list`.
+    public string Name { get; set; } = "";
+
+    // List of bot in-game names (case-insensitive) that should receive this
+    // profile when they spawn. Typically the pro's nick exactly as it appears
+    // in `bot_add_ct "<nick>"` from Commands.txt.
+    public List<string> MatchByName { get; set; } = new();
+
+    // Free-form notes shown nowhere at runtime; just so future maintainers can
+    // read a profile and understand the intent without digging through git.
+    public string Description { get; set; } = "";
+
+    // -- Behavioral flags. All default to false (= "don't touch") so a profile
+    //    can opt into only the traits that match the player.
+    public bool AlwaysRushing  { get; set; } = false;
+    public bool NeverSneaks    { get; set; } = false;
+    public bool NeverPolite    { get; set; } = false;
+    public bool NoSafeTime     { get; set; } = false;
+    public bool NoPanic        { get; set; } = false;
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -200,29 +200,30 @@ public class ProImitator : BasePlugin
         return HookResult.Continue;
     }
     // -------------------------------------------------------------------------
-    // Role-bias the bot's primary weapon, per round.
+    // Role-bias the bot's primary weapon, per round. All-or-save rule.
     //
-    // Design philosophy: we do NOT hardcode "you need X$ to buy a rifle"
-    // floors here. The engine + BotBuy already decide eco / semi-buy / full-
-    // buy each round based on the bot's account and team state. ProImitator
-    // just OBSERVES what they decided and steers the choice of weapon
-    // *within that decision*:
+    // Design philosophy: NO hardcoded "you need X$ to buy a rifle" floors.
+    // The engine + BotBuy already decide eco / semi-buy / full-buy each round
+    // based on the bot's account and team state. ProImitator just OBSERVES
+    // what they decided and either:
+    //   - swaps the wrong primary to the role's preferred (if affordable), or
+    //   - refunds the wrong primary so the bot can save for next round.
     //
-    //   - Engine bought the bot a rifle + the profile is Rifler? Swap to the
-    //     role's main rifle (AK for T, M4 for CT). Cost = price difference,
-    //     positive or negative, refunds included.
-    //   - Engine bought the bot an SMG/shotgun (= semi-buy round)? Leave it.
-    //     The bot doesn't have rifle-buy money this round, we respect that.
-    //   - Engine bought the bot nothing (= eco round)? Leave it. Pistol only.
-    //   - Engine bought the bot a rifle but the profile is AWPer? Refund the
-    //     rifle and try to buy AWP if the account covers the difference.
+    // Why "all-or-save" instead of "keep what you have": the half-buy funnel.
+    // Without the save branch, an AWPer who got a Scout from BotBuy can never
+    // afford the Scout->AWP upgrade, keeps the Scout, gets killed, buys
+    // another Scout next round, and never reaches AWP money. The refund
+    // breaks the funnel: the bot ends the round pistol-only but with
+    // accumulated cash for a real full-buy.
     //
-    // Why a separate buy hook instead of doing it in OnTick: buying / refunding
-    // is only legal during freeze, and we don't want to fight BotBuy's armor-
-    // gift / drop-weapon cycles that fire during the early freeze. We delay
-    // 3.5s after EventRoundStart so BotBuy's longest scheduled timer (3.0s)
-    // has already settled. Freeze is typically 15-20s, so we're still well
-    // inside the buy window.
+    // See TrySwapToPreferredPrimary's comment block for the case-by-case
+    // breakdown.
+    //
+    // Why a separate hook instead of OnTick: refunding / GiveNamedItem is
+    // only legal during freeze, and we don't want to fight BotBuy's armor-
+    // gift / drop-weapon cycles that fire in the early freeze. We delay 3.5s
+    // after EventRoundStart so BotBuy's longest timer (3.0s) has settled;
+    // freeze is typically 15-20s, so we're well inside the buy window.
     // -------------------------------------------------------------------------
     [GameEventHandler]
     public HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
@@ -265,20 +266,39 @@ public class ProImitator : BasePlugin
         }
     }
     // -------------------------------------------------------------------------
-    // "Same-class or better": if the bot already has a big-primary (any rifle
-    // or any sniper), we treat the round as a buy round and swap them onto
-    // the role's preferred weapon. If they have no big-primary (= pistol /
-    // SMG / shotgun / nothing), the engine + BotBuy decided it's eco or
-    // semi-buy — we leave it alone.
+    // The all-or-save rule: a role-buy activates "if possible", otherwise
+    // the bot refunds whatever wrong primary they got and saves for next
+    // round. Three cases, depending on what the engine + BotBuy gave them:
     //
-    // Net cost = preferred_price - owned_price.
-    //   - Same-tier swap (AK 2700 -> M4 2900 cross-team would never happen,
-    //     but AK 2700 -> Krieg 3000 would cost 300): tiny upgrade fee.
-    //   - Downgrade (AUG 3300 -> M4 2900): bot gets 400$ refunded.
-    //   - Upgrade (Galil 1800 -> AK 2700): 900$ deducted; if the bot can't
-    //     afford it, we skip — they keep the Galil rather than ending up
-    //     broke and rifle-less.
-    //   - Cross-class (M4 2900 -> AWP 4750 for an AWPer): 1850$ deducted.
+    //   1. Bot has no big-primary (only pistol / SMG / shotgun / nothing).
+    //      The engine read the round as eco / semi-buy — we leave it alone.
+    //      The role doesn't override CS's economy model when the bot truly
+    //      has no rifle money.
+    //
+    //   2. Bot has a big-primary AND can afford the swap to the preferred
+    //      weapon (netCost = preferredPrice - ownedPrice, possibly negative).
+    //      We refund the wrong primary, give the preferred, adjust the
+    //      account by netCost. Examples:
+    //        - AK 2700 -> Krieg 3000:        +300  small upgrade fee
+    //        - AUG 3300 -> M4 2900:          -400  bot gets a refund
+    //        - Galil 1800 -> AK 2700:        +900  if affordable
+    //        - M4 2900 -> AWP 4750 (AWPer): +1850
+    //
+    //   3. Bot has a big-primary but CAN'T afford the swap. Without this
+    //      branch, ZywOo on a force-buy round ends up holding the Scout the
+    //      engine bought him because the AWP upgrade costs more than he has.
+    //      Next round he buys another Scout (1700$ down the drain), never
+    //      reaches the 4750$ AWP threshold. Funnel of doom.
+    //
+    //      Fix: refund the wrong primary and let the bot save. He ends the
+    //      round with pistol only but +ownedPrice$ in the bank — a real save
+    //      round in pro terms.
+    //
+    // Carry-over caveat: if the bot survived last round with weapon W and
+    // we hit case 3, we refund W and credit ownedPrice$ — money the bot
+    // didn't actually spend this round. Bounded exploit (≤ 5000$ per swap,
+    // typically ≤ 1800$ for the Galil case), matches how BotBuy.Refund
+    // works in the same scenarios.
     // -------------------------------------------------------------------------
     private static void TrySwapToPreferredPrimary(
         CCSPlayerController player,
@@ -289,21 +309,31 @@ public class ProImitator : BasePlugin
         // Already holds the preferred weapon? Done.
         if (HasWeapon(pawn, preferred)) return;
 
-        // Find any rifle OR sniper currently owned. SMGs / shotguns don't
-        // count — those mean "semi-buy round, the bot didn't get rifle money
-        // and we shouldn't conjure one out of nowhere".
+        // Find any rifle OR sniper currently owned. SMGs / shotguns / pistols
+        // do NOT count — those mean the engine + BotBuy decided "eco / semi-
+        // buy round, no rifle money this round". We respect that.
         (string? ownedName, int ownedPrice) = FindOwnedBigPrimary(pawn);
         if (ownedName == null) return;
 
-        int netCost = preferredPrice - ownedPrice;
+        int  netCost   = preferredPrice - ownedPrice;
+        bool canAfford = netCost <= 0
+                      || player.InGameMoneyServices!.Account >= netCost;
 
-        // Upgrade beyond the bot's wallet -> skip. Keep current rifle rather
-        // than leave them broke + rifle-less.
-        if (netCost > 0 && player.InGameMoneyServices!.Account < netCost) return;
-
-        player.RemoveItemByDesignerName(ownedName);
-        player.GiveNamedItem(preferred);
-        player.InGameMoneyServices!.Account -= netCost;   // negative netCost = refund
+        if (canAfford)
+        {
+            // Swap: refund the wrong primary, give the preferred, pay the diff.
+            player.RemoveItemByDesignerName(ownedName);
+            player.GiveNamedItem(preferred);
+            player.InGameMoneyServices!.Account -= netCost;  // negative = refund
+        }
+        else
+        {
+            // Can't afford the role weapon. Refund the wrong primary and let
+            // the bot save. Keeps the role identity coherent ("ZywOo doesn't
+            // half-buy Scout") and stops the per-round eco bleed.
+            player.RemoveItemByDesignerName(ownedName);
+            player.InGameMoneyServices!.Account += ownedPrice;
+        }
         Utilities.SetStateChanged(player, "CCSPlayerController", "m_pInGameMoneyServices");
     }
     // -------------------------------------------------------------------------

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -101,6 +101,7 @@ public class ProImitator : BasePlugin
 
         RegisterEventHandler<EventPlayerSpawn>(OnPlayerSpawn);
         RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam);
+        RegisterEventHandler<EventRoundStart>(OnRoundStart);
         RegisterListener<Listeners.OnTick>(OnTick);
 
         // Register commands as plain game console commands (mirrors how the
@@ -197,6 +198,106 @@ public class ProImitator : BasePlugin
         }
 
         return HookResult.Continue;
+    }
+    // -------------------------------------------------------------------------
+    // Eco-aware buy of the role-preferred weapon (AK / M4 / AWP) per round.
+    //
+    // Why a separate buy hook instead of doing it in OnTick: buying mid-round
+    // is illegal once freeze time ends, and we don't want to fight BotBuy's
+    // armor-gift / drop-weapon cycles that fire during the early freeze.
+    //
+    // We delay 3.5s after EventRoundStart so BotBuy's longest scheduled timer
+    // (3.0s for the defuser pass) has already settled. Freeze time is typically
+    // 15-20s, so we still buy well inside the buy window.
+    //
+    // Eco-awareness mirrors BotBuy: the team-wide `bot_eco_limit` is 2800
+    // (skip full-buys below that), but a Rifler / AWPer wants more than just
+    // the rifle — they want rifle + armor. So we use rifle_price + 1000
+    // (kevlar+helm full price) as the floor. On eco rounds the bot keeps
+    // whatever pistol / SMG BotBuy or the engine gave them.
+    // -------------------------------------------------------------------------
+    [GameEventHandler]
+    public HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
+    {
+        if (_assigned.Count == 0) return HookResult.Continue;
+
+        AddTimer(3.5f, BuyPreferredWeapons);
+        return HookResult.Continue;
+    }
+    // -------------------------------------------------------------------------
+    private void BuyPreferredWeapons()
+    {
+        foreach (var kvp in _assigned)
+        {
+            var player = Utilities.GetPlayerFromSlot(kvp.Key);
+            if (player == null || !player.IsValid || !player.IsBot) continue;
+            if (player.InGameMoneyServices == null) continue;
+
+            var pawn = player.PlayerPawn.Value;
+            if (pawn == null || !pawn.IsValid) continue;
+
+            var prof = kvp.Value;
+            bool isT = player.Team == CsTeam.Terrorist;
+            bool isCT = player.Team == CsTeam.CounterTerrorist;
+            if (!isT && !isCT) continue;
+
+            // Rifler and AWPer should be mutually exclusive in a sane profile
+            // (template warns about this); if both true, Rifler wins by reading
+            // first — keeps behavior deterministic for misconfigured profiles.
+            if (prof.Rifler)
+            {
+                string preferred = isT ? "weapon_ak47" : "weapon_m4a1";
+                int     price     = isT ? 2700        : 2900;
+                int     fullBuy   = price + 1000;     // + kevlar+helm floor
+
+                TryBuyRolePrimary(player, pawn, preferred, price, fullBuy, FindOwnedRifle);
+            }
+            else if (prof.AWPer)
+            {
+                // AWP costs 4750; full-buy floor 5750.
+                TryBuyRolePrimary(player, pawn, "weapon_awp", 4750, 5750, FindOwnedSniper);
+            }
+        }
+    }
+    // -------------------------------------------------------------------------
+    // Shared "buy our preferred primary if we don't have one and can afford"
+    // path. ownedFinder is FindOwnedRifle / FindOwnedSniper depending on role.
+    //
+    // Skip cases (intentional, in order):
+    //   - bot already owns the EXACT preferred weapon -> done
+    //   - bot already owns a same-class weapon (Galil for Rifler, SSG08 for
+    //     AWPer) -> don't waste money on a duplicate; the per-tick `use`
+    //     switch in ApplyPersonality covers that case if they prefer ours
+    //   - bot can't afford full-buy floor -> let BotBuy / engine handle eco
+    // -------------------------------------------------------------------------
+    private static void TryBuyRolePrimary(
+        CCSPlayerController player,
+        CCSPlayerPawn pawn,
+        string preferred,
+        int price,
+        int fullBuyFloor,
+        Func<CCSPlayerPawn, string?> ownedFinder)
+    {
+        if (HasWeapon(pawn, preferred))                       return;
+        if (ownedFinder(pawn) != null)                        return;
+        if (player.InGameMoneyServices!.Account < fullBuyFloor) return;
+
+        player.GiveNamedItem(preferred);
+        player.InGameMoneyServices.Account -= price;
+        Utilities.SetStateChanged(player, "CCSPlayerController", "m_pInGameMoneyServices");
+    }
+    // -------------------------------------------------------------------------
+    private static bool HasWeapon(CCSPlayerPawn pawn, string designerName)
+    {
+        var weapons = pawn.WeaponServices?.MyWeapons;
+        if (weapons == null) return false;
+
+        foreach (var handle in weapons)
+        {
+            var w = handle.Value;
+            if (w != null && w.IsValid && w.DesignerName == designerName) return true;
+        }
+        return false;
     }
     // -------------------------------------------------------------------------
     private ProProfile? MatchProfile(string botName)
@@ -425,16 +526,17 @@ public class ProImitator : BasePlugin
             _wasAimingAtEnemy[player.Slot] = isAimingAtEnemy;
         }
 
-        if (prof.RifleOnly)
+        if (prof.Rifler)
         {
-            // Force-prefer rifles when the bot is holding something else but
-            // already owns a rifle (typically picked up via BotBuy's
-            // coordinated rifle commands, or off the ground).
+            // Switch-back half of the Rifler trait. The eco-aware *buy* half
+            // runs in OnRoundFreezeEnded (post round-start, once per round);
+            // here we just keep the bot on its rifle if it picks up a pistol
+            // off the ground or drops to a knife after running out of ammo.
             //
-            // We do NOT call GiveNamedItem here — that would break the game's
-            // economy and let the bot have a free rifle every round. Instead
-            // we issue a `use weapon_<name>` command in the bot's context,
-            // which only succeeds if the weapon is already in inventory.
+            // GiveNamedItem is NOT called here — see the per-round buy logic
+            // for that. We issue `use weapon_<name>` which only succeeds if
+            // the weapon is already in inventory, so we never duplicate a
+            // rifle or give one for free.
             //
             // A 0.5s cooldown prevents spamming the engine: the swap takes a
             // few ticks to resolve, and the next tick after we issue would
@@ -453,12 +555,12 @@ public class ProImitator : BasePlugin
             }
         }
 
-        if (prof.AwpOnly)
+        if (prof.AWPer)
         {
-            // AWPer mirror of RifleOnly: prefer the sniper when the bot is
-            // holding a non-sniper but already owns one. Same cooldown, same
-            // no-give policy — we don't conjure an AWP, we just demand the
-            // bot switch back to it once it's in inventory.
+            // AWPer mirror of the Rifler switch-back. Same cooldown, same
+            // no-give policy: the per-round buy of the AWP happens in
+            // OnRoundFreezeEnded; here we just prevent the bot from running
+            // around with a teammate's rifle once it has the AWP available.
             bool holdingSniper = activeWeapon != null && SniperDesignerNames.Contains(activeWeapon);
             if (!holdingSniper
                 && (!_lastWeaponSwitchAt.TryGetValue(player.Slot, out float lastAt)
@@ -626,15 +728,19 @@ public sealed class ProProfile
     public bool NeverWaitsBetweenShots { get; set; } = false;
     public bool NoApproachPause      { get; set; } = false;
 
-    // Force-switch to a rifle whenever the bot is holding a non-rifle AND has
-    // a rifle in inventory. Does NOT give weapons (would break the economy);
-    // pair with a coordinated BotBuy of `ak47` / `m4a1` / `aug` etc.
-    public bool RifleOnly            { get; set; } = false;
+    // "I main rifles." Two effects, both eco-aware:
+    //   1. At round-freeze, if the bot can afford a full buy (rifle + armor)
+    //      and doesn't already own a rifle, give them their team's main
+    //      rifle (AK for T, M4 for CT) and deduct the price. We DON'T buy
+    //      on eco rounds — BotBuy / the engine handle pistol / SMG rounds.
+    //   2. Per tick, if the bot is holding a non-rifle but already owns one,
+    //      `use weapon_*` switches them back to it.
+    public bool Rifler               { get; set; } = false;
 
-    // AWPer mirror of RifleOnly. Force-switch back to AWP / Scout whenever
-    // the bot is holding something else. Same no-give policy: requires the
-    // bot to already own the sniper (typically via the buyscript).
-    public bool AwpOnly              { get; set; } = false;
+    // AWPer mirror of Rifler. Same eco-aware buy at round-freeze (AWP costs
+    // 4750, so the full-buy floor is 5750 with armor), same per-tick
+    // switch-back behavior if the bot drops to a teammate's dropped rifle.
+    public bool AWPer                { get; set; } = false;
 
     // Counter-strafe at engagement onset, gated by probability so the bot
     // doesn't read as aimbot. On the false->true edge of IsAimingAtEnemy

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -562,31 +562,34 @@ public class ProImitator : BasePlugin
         //
         // V4.1 added: pre/post-plant inversion + bomb carrier extra push.
         //
-        // V4.2 tone-down (current): V4.1's effects were too heavy in play-
-        // tests — bots looked like "locomotives" running through cover.
-        // The fix is to keep the strategic intent (push site / hold site /
-        // invert post-plant) but make every field write a NUDGE rather than
-        // an override:
-        //   - HurryTimer Duration dropped from 600s (perpetual max) to 10s
-        //     (still refreshed each tick, but with a short "horizon" the
-        //     engine pathing code can interpret as bias, not absolute).
-        //   - CheckedHidingSpotCount=0 REMOVED. That was the line that made
-        //     bots ignore cover. Now the engine's hiding-spot checks run
-        //     normally, just with HurryTimer favouring the objective route.
-        //   - Defender SafeTime dropped from 8s to 3s. Less jumpy on peeks
-        //     but still reacts to clear threats.
-        //   - Bomb carrier no longer gets IsRunning=true and the wait-timer
-        //     wipe. They keep strategic behaviour (cover, peeks, patience)
-        //     and only get a slightly longer hurry horizon (20s vs 10s for
-        //     other Ts) as the "slightly more site-focused than teammates"
-        //     bias the user asked for.
+        // V4.2 tone-down: V4.1 was too heavy ("locomotives"). Switched to
+        // small Duration values (10-20s) and removed CheckedHidingSpotCount=0
+        // override.
         //
-        // What BombFocus does per phase (V4.2 values):
+        // V4.3 calibration (current): V4.2 was too soft on the defending
+        // side and the bomb carrier was indistinguishable from teammates.
+        // Three targeted bumps:
+        //   - CT (and post-plant T) defenders: HurryTimer EXPLICITLY cleared
+        //     (Duration=0, Timestamp=0). Critical because Entry-tagged bots
+        //     on the defending side still have AlwaysRushing in their
+        //     profile, which writes HurryTimer.Duration=600 every tick. If
+        //     BombFocus only writes SafeTime, the AlwaysRushing bot still
+        //     rushes — they look "agressifs trop de fight en dehors des BP".
+        //     The clear here wins the per-tick race against AlwaysRushing.
+        //   - Defender SafeTime raised 3s → 6s. Still not the V4.1 8s, but
+        //     more committed-to-position.
+        //   - Bomb carrier: HurryTimer 20s → 30s AND IsRunning forced true.
+        //     The forced run (no walk) is the visible difference between the
+        //     carrier and other Ts, without the V4.1 timer-wipe extremes
+        //     (SneakTimer / PoliteTimer / IsWaitingBehindFriend still
+        //     untouched — they can still use cover and trade).
+        //
+        // What BombFocus does per phase (V4.3 values):
         //   PRE-PLANT  T (attacker):  HurryTimer.Duration = 10s, refreshed
-        //                             Bomb carrier: HurryTimer.Duration = 20s
-        //              CT (defender): SafeTime = 3s, refreshed
+        //                             Bomb carrier: HurryTimer 30s + IsRunning
+        //              CT (defender): SafeTime = 6s + HurryTimer cleared
         //
-        //   POST-PLANT T (defender):  SafeTime = 3s, refreshed
+        //   POST-PLANT T (defender):  SafeTime = 6s + HurryTimer cleared
         //              CT (attacker): HurryTimer.Duration = 10s, refreshed
         //
         // What BombFocus deliberately does NOT do:
@@ -649,34 +652,51 @@ public class ProImitator : BasePlugin
             }
             else if (isDefender)
             {
-                // Subtle hold bias: SafeTime 3s (V4.1 used 8s). Bot stays
-                // slightly less jumpy on early-round peeks but still
-                // reacts to clear threats. We deliberately do NOT clear
-                // HurryTimer — the engine should keep its natural ability
-                // to chase a wounded enemy or rotate when needed.
+                // Hold bias: SafeTime 6s + HurryTimer EXPLICITLY cleared.
+                //
+                // The HurryTimer clear is the critical bit. Entry profiles
+                // (flameZ on Vitality CT, kyousuke on Falcons CT, makazze
+                // on NaVi CT, …) set HurryTimer.Duration=600 every tick via
+                // their AlwaysRushing trait. Without an explicit clear here,
+                // the defender behaviour gets overwritten and the Entry-
+                // tagged CT just rushes mid as if they were still on T.
+                // SafeTime alone is not enough to override that.
                 ref float safeTime = ref bot.SafeTime;
-                safeTime           = 3.0f;
+                safeTime           = 6.0f;
+
+                CountdownTimer hurry = bot.HurryTimer;
+
+                ref float hurryDuration  = ref hurry.Duration;
+                hurryDuration            = 0.0f;
+
+                ref float hurryTimestamp = ref hurry.Timestamp;
+                hurryTimestamp           = 0.0f;
             }
 
-            // Bomb carrier on pre-plant T-side: slightly more site-focused
-            // than the rest of the T side, but still strategic. They keep
-            // strategic behaviour intact — they use cover, take peeks, wait
-            // for trades — they just have a longer hurry horizon (20s vs
-            // 10s for the other Ts) so they're less likely to peel back to
-            // lurk or back-trade. The V4.1 carrier hack (force IsRunning,
-            // wipe SneakTimer / PoliteTimer / IsWaitingBehindFriend) was
-            // removed: it made the carrier behave like a hold-W zombie
-            // instead of a pro who knows the bomb still needs to be brought
-            // to site safely.
+            // Bomb carrier on pre-plant T-side: more site-focused than the
+            // rest of the T side, but still strategic. V4.3 = HurryTimer
+            // 30s (vs 10s for other Ts) + IsRunning=true (always runs, no
+            // walk). The forced run is the visible "this bot is on
+            // mission" signal; the longer hurry horizon biases their path
+            // choice toward the assigned site.
+            //
+            // V4.1's full timer wipe (SneakTimer / PoliteTimer /
+            // IsWaitingBehindFriend cleared) stays REMOVED — those wiped
+            // away the "strategic" behaviour the user wants the carrier
+            // to keep. They still use cover, still wait for trades, still
+            // pause at angles; they just run a bit faster toward the site.
             if (isT && !_bombPlanted && IsCarryingBomb(pawn))
             {
                 CountdownTimer hurry = bot.HurryTimer;
 
                 ref float hurryDuration  = ref hurry.Duration;
-                hurryDuration            = 20.0f;
+                hurryDuration            = 30.0f;
 
                 ref float hurryTimestamp = ref hurry.Timestamp;
-                hurryTimestamp           = now + 20.0f;
+                hurryTimestamp           = now + 30.0f;
+
+                ref bool isRunning = ref bot.IsRunning;
+                isRunning = true;
             }
         }
 

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -63,6 +63,12 @@ public class ProImitator : BasePlugin
     // change so a bot moved to spectator drops its personality cleanly.
     private readonly Dictionary<int, ProProfile> _assigned = new();
 
+    // Cooldown per bot for the RifleOnly weapon switch. Without it we'd send
+    // a `use weapon_*` command every tick (64Hz) which spams the engine and
+    // prevents the swap from ever resolving.
+    private readonly Dictionary<int, float> _lastWeaponSwitchAt = new();
+    private const float WeaponSwitchCooldownSec = 0.5f;
+
     // -------------------------------------------------------------------------
     public override void Load(bool hotReload)
     {
@@ -152,6 +158,7 @@ public class ProImitator : BasePlugin
             && (CsTeam)@event.Team != CsTeam.Terrorist)
         {
             _assigned.Remove(player.Slot);
+            _lastWeaponSwitchAt.Remove(player.Slot);
         }
 
         return HookResult.Continue;
@@ -204,7 +211,7 @@ public class ProImitator : BasePlugin
             // Weapon name is needed by a couple of traits. Cheap to read once.
             string? activeWeapon = pawn.WeaponServices?.ActiveWeapon?.Value?.DesignerName;
 
-            ApplyPersonality(bot, pawn, prof, now, activeWeapon);
+            ApplyPersonality(player, bot, pawn, prof, now, activeWeapon);
         }
     }
     // -------------------------------------------------------------------------
@@ -213,7 +220,7 @@ public class ProImitator : BasePlugin
     // Each block is opt-in; profiles can mix-and-match. Anything not listed in
     // a profile is left untouched (BotState's generic improvements still apply).
     // -------------------------------------------------------------------------
-    private static void ApplyPersonality(CCSBot bot, CCSPlayerPawn pawn, ProProfile prof, float now, string? activeWeapon)
+    private void ApplyPersonality(CCSPlayerController player, CCSBot bot, CCSPlayerPawn pawn, ProProfile prof, float now, string? activeWeapon)
     {
         if (prof.AlwaysRushing)
         {
@@ -344,6 +351,55 @@ public class ProImitator : BasePlugin
             ref int checkedHidingSpotCount = ref bot.CheckedHidingSpotCount;
             checkedHidingSpotCount = 0;
         }
+
+        if (prof.RifleOnly)
+        {
+            // Force-prefer rifles when the bot is holding something else but
+            // already owns a rifle (typically picked up via BotBuy's
+            // coordinated rifle commands, or off the ground).
+            //
+            // We do NOT call GiveNamedItem here — that would break the game's
+            // economy and let the bot have a free rifle every round. Instead
+            // we issue a `use weapon_<name>` command in the bot's context,
+            // which only succeeds if the weapon is already in inventory.
+            //
+            // A 0.5s cooldown prevents spamming the engine: the swap takes a
+            // few ticks to resolve, and the next tick after we issue would
+            // still see the old activeWeapon.
+            bool holdingRifle = activeWeapon != null && RifleDesignerNames.Contains(activeWeapon);
+            if (!holdingRifle
+                && (!_lastWeaponSwitchAt.TryGetValue(player.Slot, out float lastAt)
+                    || now - lastAt > WeaponSwitchCooldownSec))
+            {
+                string? rifleToUse = FindOwnedRifle(pawn);
+                if (rifleToUse != null)
+                {
+                    NativeAPI.IssueClientCommand((int)player.Slot, $"use {rifleToUse}");
+                    _lastWeaponSwitchAt[player.Slot] = now;
+                }
+            }
+        }
+    }
+    // -------------------------------------------------------------------------
+    // Walk the bot's weapon inventory and return the designer name of the
+    // first rifle found, or null if none. Used by RifleOnly to know what to
+    // pass to `use <weapon_*>`.
+    // -------------------------------------------------------------------------
+    private static string? FindOwnedRifle(CCSPlayerPawn pawn)
+    {
+        var weapons = pawn.WeaponServices?.MyWeapons;
+        if (weapons == null) return null;
+
+        foreach (var handle in weapons)
+        {
+            var weapon = handle.Value;
+            if (weapon == null || !weapon.IsValid) continue;
+
+            string? designer = weapon.DesignerName;
+            if (designer != null && RifleDesignerNames.Contains(designer))
+                return designer;
+        }
+        return null;
     }
     // -------------------------------------------------------------------------
     // Console commands. Mirrors the convention used elsewhere in the suite:
@@ -452,4 +508,9 @@ public sealed class ProProfile
     public bool NoCrouchWithRifle    { get; set; } = false;
     public bool NeverWaitsBetweenShots { get; set; } = false;
     public bool NoApproachPause      { get; set; } = false;
+
+    // Force-switch to a rifle whenever the bot is holding a non-rifle AND has
+    // a rifle in inventory. Does NOT give weapons (would break the economy);
+    // pair with a coordinated BotBuy of `ak47` / `m4a1` / `aug` etc.
+    public bool RifleOnly            { get; set; } = false;
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -350,6 +350,14 @@ public class ProImitator : BasePlugin
             // Rifler wins by reading first.
             if (prof.Rifler)
             {
+                // V4.7 — pickup-respect: if the bot already has ANY rifle
+                // (e.g. a CT mezii carrying over the AK he picked up off a
+                // dead T last round), don't force the role primary. Skip
+                // the M4 buy and let him keep the AK. AK is the universal
+                // pro favourite — no Rifler profile would willingly drop
+                // it for a M4 just because they're on CT.
+                if (FindOwnedRifle(pawn) != null) continue;
+
                 // Prices mirror BotBuy.cs price table (AK 2700, M4A4 2900).
                 string preferred = isT ? "weapon_ak47" : "weapon_m4a1";
                 int    price     = isT ? 2700        : 2900;
@@ -357,6 +365,10 @@ public class ProImitator : BasePlugin
             }
             else if (prof.AWPer)
             {
+                // Same pickup-respect logic for AWPers — if they already
+                // have any sniper (AWP or SSG08), don't force-buy on top.
+                if (FindOwnedSniper(pawn) != null) continue;
+
                 TryBuyRoleWeapon(player, pawn, "weapon_awp", 4750);
             }
         }
@@ -894,17 +906,26 @@ public class ProImitator : BasePlugin
             bool holdingKnife = activeWeapon != null && activeWeapon.StartsWith("weapon_knife");
             if (!holdingKnife)
             {
-                // V4.6 — `bot_command` does not exist in CS2 (verified by
-                // "Unknown command: bot_command" log spam in playtests). The
-                // dual-path V4.1 trick is gone; we keep only `slot3`. If the
-                // bot AI continues to outrace `slot3`, the next escalation
-                // would be a direct schema write to
-                // pawn.WeaponServices.ActiveWeapon (not implemented yet —
-                // brittle without confirmed schema-field semantics in CSS).
+                // V4.7 — direct schema write to the active-weapon handle.
                 //
-                // No cooldown: re-issue every tick until activeWeapon
-                // actually becomes a knife. Once holdingKnife=true the loop
-                // stops issuing.
+                // None of the other plugins in the ed0ard suite (BotState,
+                // BotAI, BotBuy, BotAimImprover) attempt active-weapon
+                // switching for bots, so we have no reference pattern.
+                // Playtests confirmed `slot3` and `use weapon_knife`
+                // commands lose the race against the engine's bot-AI weapon
+                // selection (which runs every server tick).
+                //
+                // Schema write bypasses the command queue entirely: we set
+                // CPlayer_WeaponServices.m_hActiveWeapon directly to the
+                // knife's handle, then SetStateChanged tells the network
+                // layer to broadcast the update. The engine reads this
+                // field on the same tick its bot-AI runs, so we no longer
+                // race.
+                //
+                // We keep the `slot3` issue as a belt-and-braces fallback:
+                // if the schema write ever fails (CS2 schema rename, CSS
+                // API change), the command path still tries.
+                TrySetActiveKnife(pawn);
                 NativeAPI.IssueClientCommand((int)player.Slot, "slot3");
             }
         }
@@ -954,6 +975,54 @@ public class ProImitator : BasePlugin
                     _lastWeaponSwitchAt[player.Slot] = now;
                 }
             }
+        }
+    }
+    // -------------------------------------------------------------------------
+    // V4.7 — Direct schema-level active-weapon switch to a knife. Bypasses
+    // the command queue (which the bot AI was outracing for `slot3`).
+    //
+    // Mechanism: walk MyWeapons, find a weapon_knife*, copy its handle's
+    // raw uint into m_hActiveWeapon on the pawn's WeaponServices, then
+    // SetStateChanged so the network layer broadcasts the change.
+    //
+    // Caveats (read before touching):
+    //   - This assumes CSS exposes a settable `.Raw` on NetworkedCHandle.
+    //     If a future CSS update locks that, this no-ops silently and the
+    //     `slot3` fallback in the caller takes over.
+    //   - Schema-field path "m_pWeaponServices" matches the embedded sub-
+    //     object on CCSPlayerPawn. If a CS2 schema rename ever changes
+    //     this, SetStateChanged becomes a no-op and the engine still
+    //     reads the old handle until next natural switch.
+    //   - The try/catch swallows any unexpected nulls — silent failure is
+    //     preferable to crashing the server tick for an observability /
+    //     polish feature.
+    // -------------------------------------------------------------------------
+    private static void TrySetActiveKnife(CCSPlayerPawn pawn)
+    {
+        try
+        {
+            var ws = pawn.WeaponServices;
+            if (ws == null) return;
+            var myWeapons = ws.MyWeapons;
+            if (myWeapons == null) return;
+
+            foreach (var handle in myWeapons)
+            {
+                var weapon = handle.Value;
+                if (weapon == null || !weapon.IsValid) continue;
+                string? designer = weapon.DesignerName;
+                if (designer == null || !designer.StartsWith("weapon_knife")) continue;
+
+                // Set ActiveWeapon to point at this knife handle.
+                ws.ActiveWeapon.Raw = handle.Raw;
+                Utilities.SetStateChanged(pawn, "CCSPlayerPawn", "m_pWeaponServices");
+                return;
+            }
+        }
+        catch
+        {
+            // Schema field renamed, handle API changed, or pawn pointer
+            // briefly invalid. Caller still issues slot3 as fallback.
         }
     }
     // -------------------------------------------------------------------------
@@ -1037,24 +1106,34 @@ public class ProImitator : BasePlugin
     }
     // -------------------------------------------------------------------------
     // Walk the bot's weapon inventory and return the designer name of the
-    // first rifle found, or null if none. Used by RifleOnly to know what to
-    // pass to `use <weapon_*>`.
+    // preferred rifle, or null if none.
+    //
+    // V4.7 — AK preference. AK-47 is the universal pro favourite (T main
+    // weapon, but CTs who pick one up off a corpse also keep it over their
+    // M4 — see ESL meta + the user's V4.7 spec). When the bot has both an
+    // M4 and a picked-up AK in inventory, we return the AK so the per-tick
+    // Rifler switch picks it.
     // -------------------------------------------------------------------------
     private static string? FindOwnedRifle(CCSPlayerPawn pawn)
     {
         var weapons = pawn.WeaponServices?.MyWeapons;
         if (weapons == null) return null;
 
+        // Two-pass: return AK immediately if owned, otherwise the first
+        // non-AK rifle we find.
+        string? fallback = null;
         foreach (var handle in weapons)
         {
             var weapon = handle.Value;
             if (weapon == null || !weapon.IsValid) continue;
 
             string? designer = weapon.DesignerName;
-            if (designer != null && RifleDesignerNames.Contains(designer))
-                return designer;
+            if (designer == null) continue;
+
+            if (designer == "weapon_ak47") return designer;
+            if (fallback == null && RifleDesignerNames.Contains(designer)) fallback = designer;
         }
-        return null;
+        return fallback;
     }
     // -------------------------------------------------------------------------
     // Sniper-equivalent of FindOwnedRifle. AWP wins ties: we iterate in the

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -200,32 +200,40 @@ public class ProImitator : BasePlugin
         return HookResult.Continue;
     }
     // -------------------------------------------------------------------------
-    // Eco-aware buy of the role-preferred weapon (AK / M4 / AWP) per round.
+    // Role-bias the bot's primary weapon, per round.
     //
-    // Why a separate buy hook instead of doing it in OnTick: buying mid-round
-    // is illegal once freeze time ends, and we don't want to fight BotBuy's
-    // armor-gift / drop-weapon cycles that fire during the early freeze.
+    // Design philosophy: we do NOT hardcode "you need X$ to buy a rifle"
+    // floors here. The engine + BotBuy already decide eco / semi-buy / full-
+    // buy each round based on the bot's account and team state. ProImitator
+    // just OBSERVES what they decided and steers the choice of weapon
+    // *within that decision*:
     //
-    // We delay 3.5s after EventRoundStart so BotBuy's longest scheduled timer
-    // (3.0s for the defuser pass) has already settled. Freeze time is typically
-    // 15-20s, so we still buy well inside the buy window.
+    //   - Engine bought the bot a rifle + the profile is Rifler? Swap to the
+    //     role's main rifle (AK for T, M4 for CT). Cost = price difference,
+    //     positive or negative, refunds included.
+    //   - Engine bought the bot an SMG/shotgun (= semi-buy round)? Leave it.
+    //     The bot doesn't have rifle-buy money this round, we respect that.
+    //   - Engine bought the bot nothing (= eco round)? Leave it. Pistol only.
+    //   - Engine bought the bot a rifle but the profile is AWPer? Refund the
+    //     rifle and try to buy AWP if the account covers the difference.
     //
-    // Eco-awareness mirrors BotBuy: the team-wide `bot_eco_limit` is 2800
-    // (skip full-buys below that), but a Rifler / AWPer wants more than just
-    // the rifle — they want rifle + armor. So we use rifle_price + 1000
-    // (kevlar+helm full price) as the floor. On eco rounds the bot keeps
-    // whatever pistol / SMG BotBuy or the engine gave them.
+    // Why a separate buy hook instead of doing it in OnTick: buying / refunding
+    // is only legal during freeze, and we don't want to fight BotBuy's armor-
+    // gift / drop-weapon cycles that fire during the early freeze. We delay
+    // 3.5s after EventRoundStart so BotBuy's longest scheduled timer (3.0s)
+    // has already settled. Freeze is typically 15-20s, so we're still well
+    // inside the buy window.
     // -------------------------------------------------------------------------
     [GameEventHandler]
     public HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
     {
         if (_assigned.Count == 0) return HookResult.Continue;
 
-        AddTimer(3.5f, BuyPreferredWeapons);
+        AddTimer(3.5f, SwapPreferredPrimaries);
         return HookResult.Continue;
     }
     // -------------------------------------------------------------------------
-    private void BuyPreferredWeapons()
+    private void SwapPreferredPrimaries()
     {
         foreach (var kvp in _assigned)
         {
@@ -241,59 +249,102 @@ public class ProImitator : BasePlugin
             bool isCT = player.Team == CsTeam.CounterTerrorist;
             if (!isT && !isCT) continue;
 
-            // Rifler and AWPer should be mutually exclusive in a sane profile
-            // (template warns about this); if both true, Rifler wins by reading
-            // first — keeps behavior deterministic for misconfigured profiles.
+            // Rifler / AWPer should be mutually exclusive (template warns); if
+            // both true Rifler wins by reading first.
             if (prof.Rifler)
             {
                 // Prices mirror BotBuy.cs price table (AK 2700, M4A1 2900).
                 string preferred = isT ? "weapon_ak47" : "weapon_m4a1";
                 int     price     = isT ? 2700        : 2900;
-
-                // Full-buy floor = rifle + armor + min nade kit. A pro full-buy
-                // is roughly rifle (2700-2900) + armor (1000) + 1-2 nades
-                // (smoke 300, flash 200, molly/HE 300-500) -> ~4700-5100. We
-                // pick 5000 as a round number that's strict enough that
-                // tagging a "Rifler" never triggers a half-buy panic-rifle
-                // on a 3500$ account.
-                TryBuyRolePrimary(player, pawn, preferred, price, 5000, FindOwnedRifle);
+                TrySwapToPreferredPrimary(player, pawn, preferred, price);
             }
             else if (prof.AWPer)
             {
-                // AWP 4750 + armor 1000 + nades + pistol upgrade ≈ 6500. The
-                // floor is high on purpose: a pro who can't afford the full
-                // AWP kit shouldn't get a "naked AWP" buy that leaves them
-                // with no utility and a bad pistol.
-                TryBuyRolePrimary(player, pawn, "weapon_awp", 4750, 6500, FindOwnedSniper);
+                TrySwapToPreferredPrimary(player, pawn, "weapon_awp", 4750);
             }
         }
     }
     // -------------------------------------------------------------------------
-    // Shared "buy our preferred primary if we don't have one and can afford"
-    // path. ownedFinder is FindOwnedRifle / FindOwnedSniper depending on role.
+    // "Same-class or better": if the bot already has a big-primary (any rifle
+    // or any sniper), we treat the round as a buy round and swap them onto
+    // the role's preferred weapon. If they have no big-primary (= pistol /
+    // SMG / shotgun / nothing), the engine + BotBuy decided it's eco or
+    // semi-buy — we leave it alone.
     //
-    // Skip cases (intentional, in order):
-    //   - bot already owns the EXACT preferred weapon -> done
-    //   - bot already owns a same-class weapon (Galil for Rifler, SSG08 for
-    //     AWPer) -> don't waste money on a duplicate; the per-tick `use`
-    //     switch in ApplyPersonality covers that case if they prefer ours
-    //   - bot can't afford full-buy floor -> let BotBuy / engine handle eco
+    // Net cost = preferred_price - owned_price.
+    //   - Same-tier swap (AK 2700 -> M4 2900 cross-team would never happen,
+    //     but AK 2700 -> Krieg 3000 would cost 300): tiny upgrade fee.
+    //   - Downgrade (AUG 3300 -> M4 2900): bot gets 400$ refunded.
+    //   - Upgrade (Galil 1800 -> AK 2700): 900$ deducted; if the bot can't
+    //     afford it, we skip — they keep the Galil rather than ending up
+    //     broke and rifle-less.
+    //   - Cross-class (M4 2900 -> AWP 4750 for an AWPer): 1850$ deducted.
     // -------------------------------------------------------------------------
-    private static void TryBuyRolePrimary(
+    private static void TrySwapToPreferredPrimary(
         CCSPlayerController player,
         CCSPlayerPawn pawn,
         string preferred,
-        int price,
-        int fullBuyFloor,
-        Func<CCSPlayerPawn, string?> ownedFinder)
+        int preferredPrice)
     {
-        if (HasWeapon(pawn, preferred))                       return;
-        if (ownedFinder(pawn) != null)                        return;
-        if (player.InGameMoneyServices!.Account < fullBuyFloor) return;
+        // Already holds the preferred weapon? Done.
+        if (HasWeapon(pawn, preferred)) return;
 
+        // Find any rifle OR sniper currently owned. SMGs / shotguns don't
+        // count — those mean "semi-buy round, the bot didn't get rifle money
+        // and we shouldn't conjure one out of nowhere".
+        (string? ownedName, int ownedPrice) = FindOwnedBigPrimary(pawn);
+        if (ownedName == null) return;
+
+        int netCost = preferredPrice - ownedPrice;
+
+        // Upgrade beyond the bot's wallet -> skip. Keep current rifle rather
+        // than leave them broke + rifle-less.
+        if (netCost > 0 && player.InGameMoneyServices!.Account < netCost) return;
+
+        player.RemoveItemByDesignerName(ownedName);
         player.GiveNamedItem(preferred);
-        player.InGameMoneyServices.Account -= price;
+        player.InGameMoneyServices!.Account -= netCost;   // negative netCost = refund
         Utilities.SetStateChanged(player, "CCSPlayerController", "m_pInGameMoneyServices");
+    }
+    // -------------------------------------------------------------------------
+    // Scan the bot's inventory for the first owned rifle / sniper and return
+    // its designer name + BotBuy-canonical price. Returns (null, 0) if the
+    // bot only has SMGs / shotguns / pistols.
+    //
+    // Price table mirrors BotBuy.cs — keep in sync if upstream ever changes.
+    // -------------------------------------------------------------------------
+    private static readonly Dictionary<string, int> BigPrimaryPrices = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Rifles
+        { "weapon_ak47",            2700 },
+        { "weapon_m4a1",            2900 },
+        { "weapon_m4a1_silencer",   2900 },
+        { "weapon_sg556",           3000 },
+        { "weapon_aug",             3300 },
+        { "weapon_galilar",         1800 },
+        { "weapon_famas",           1950 },
+        // Snipers
+        { "weapon_awp",             4750 },
+        { "weapon_ssg08",           1700 },
+        { "weapon_scar20",          5000 },
+        { "weapon_g3sg1",           5000 },
+    };
+
+    private static (string? name, int price) FindOwnedBigPrimary(CCSPlayerPawn pawn)
+    {
+        var weapons = pawn.WeaponServices?.MyWeapons;
+        if (weapons == null) return (null, 0);
+
+        foreach (var handle in weapons)
+        {
+            var w = handle.Value;
+            if (w == null || !w.IsValid) continue;
+
+            string? n = w.DesignerName;
+            if (n != null && BigPrimaryPrices.TryGetValue(n, out int p))
+                return (n, p);
+        }
+        return (null, 0);
     }
     // -------------------------------------------------------------------------
     private static bool HasWeapon(CCSPlayerPawn pawn, string designerName)
@@ -737,18 +788,20 @@ public sealed class ProProfile
     public bool NeverWaitsBetweenShots { get; set; } = false;
     public bool NoApproachPause      { get; set; } = false;
 
-    // "I main rifles." Two effects, both eco-aware:
-    //   1. At round-freeze, if the bot can afford a full buy (rifle + armor)
-    //      and doesn't already own a rifle, give them their team's main
-    //      rifle (AK for T, M4 for CT) and deduct the price. We DON'T buy
-    //      on eco rounds — BotBuy / the engine handle pistol / SMG rounds.
+    // "I main rifles." Two effects, both deferring eco-vs-buy decisions to
+    // the engine + BotBuy:
+    //   1. At round-freeze, if the bot was given ANY rifle/sniper by the
+    //      engine, swap it for the role's main rifle (AK for T, M4 for CT)
+    //      and pay only the price difference. If they only got a pistol /
+    //      SMG / shotgun, leave it (= the round is eco/semi-buy per the
+    //      engine's read, we don't override that).
     //   2. Per tick, if the bot is holding a non-rifle but already owns one,
     //      `use weapon_*` switches them back to it.
     public bool Rifler               { get; set; } = false;
 
-    // AWPer mirror of Rifler. Same eco-aware buy at round-freeze (AWP costs
-    // 4750, so the full-buy floor is 5750 with armor), same per-tick
-    // switch-back behavior if the bot drops to a teammate's dropped rifle.
+    // AWPer mirror of Rifler. Same swap-not-buy logic: if the bot got a
+    // primary, swap it to AWP (paying the diff); if they only got a small
+    // primary or nothing, leave it. Same per-tick switch-back behavior.
     public bool AWPer                { get; set; } = false;
 
     // Counter-strafe at engagement onset, gated by probability so the bot

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -38,13 +38,14 @@ namespace ProImitator;
 public class ProImitator : BasePlugin
 {
     public override string ModuleName        => "Pro-Imitator";
-    public override string ModuleVersion     => "0.2.0";
+    public override string ModuleVersion     => "0.3.0";
     public override string ModuleAuthor      => "Contribution to ed0ard/CS2-Bot-Improver";
     public override string ModuleDescription => "Per-bot personality presets so the donk bot plays like donk";
 
-    // Weapon classifier used by NoCrouchWithRifle. Anything not in this set
-    // (pistols, SMGs, snipers, shotguns) keeps the BotState default crouch
-    // behavior so a profiled bot still crouches with e.g. a Deagle pop.
+    // Weapon classifier used by NoCrouchWithRifle and RifleOnly. Anything
+    // not in this set (pistols, SMGs, snipers, shotguns) keeps the BotState
+    // default crouch behavior so a profiled bot still crouches with e.g. a
+    // Deagle pop.
     private static readonly HashSet<string> RifleDesignerNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "weapon_ak47",
@@ -54,6 +55,15 @@ public class ProImitator : BasePlugin
         "weapon_aug",
         "weapon_galilar",
         "weapon_famas",
+    };
+
+    // Sniper classifier used by AwpOnly. AWPers (ZywOo, m0NESY, s1mple) want
+    // to stick to their main; Scout / SSG08 included since it's the cheap
+    // sniper a pro will pull on pistol rounds.
+    private static readonly HashSet<string> SniperDesignerNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "weapon_awp",
+        "weapon_ssg08",      // Scout
     };
 
     // Loaded profiles, keyed by their JSON 'Name' (lowercased) for de-dup.
@@ -442,6 +452,26 @@ public class ProImitator : BasePlugin
                 }
             }
         }
+
+        if (prof.AwpOnly)
+        {
+            // AWPer mirror of RifleOnly: prefer the sniper when the bot is
+            // holding a non-sniper but already owns one. Same cooldown, same
+            // no-give policy — we don't conjure an AWP, we just demand the
+            // bot switch back to it once it's in inventory.
+            bool holdingSniper = activeWeapon != null && SniperDesignerNames.Contains(activeWeapon);
+            if (!holdingSniper
+                && (!_lastWeaponSwitchAt.TryGetValue(player.Slot, out float lastAt)
+                    || now - lastAt > WeaponSwitchCooldownSec))
+            {
+                string? sniperToUse = FindOwnedSniper(pawn);
+                if (sniperToUse != null)
+                {
+                    NativeAPI.IssueClientCommand((int)player.Slot, $"use {sniperToUse}");
+                    _lastWeaponSwitchAt[player.Slot] = now;
+                }
+            }
+        }
     }
     // -------------------------------------------------------------------------
     // Walk the bot's weapon inventory and return the designer name of the
@@ -465,6 +495,27 @@ public class ProImitator : BasePlugin
         return null;
     }
     // -------------------------------------------------------------------------
+    // Sniper-equivalent of FindOwnedRifle. AWP wins ties: we iterate in the
+    // order MyWeapons returns, but pros holding both AWP and Scout would
+    // always pick the AWP anyway, and the engine returns the primary first.
+    // -------------------------------------------------------------------------
+    private static string? FindOwnedSniper(CCSPlayerPawn pawn)
+    {
+        var weapons = pawn.WeaponServices?.MyWeapons;
+        if (weapons == null) return null;
+
+        foreach (var handle in weapons)
+        {
+            var weapon = handle.Value;
+            if (weapon == null || !weapon.IsValid) continue;
+
+            string? designer = weapon.DesignerName;
+            if (designer != null && SniperDesignerNames.Contains(designer))
+                return designer;
+        }
+        return null;
+    }
+    // -------------------------------------------------------------------------
     // Console commands. Exposed via AddCommand (not the `[ConsoleCommand]`
     // attribute with a `css_*` name) so they behave like the suite's other
     // user-facing commands (`bot_aim`, `bot_nades`) instead of hitting the CSS
@@ -482,7 +533,8 @@ public class ProImitator : BasePlugin
         foreach (var prof in _profiles.Values.OrderBy(p => p.Name))
         {
             string aliases = prof.MatchByName.Count > 0 ? string.Join(", ", prof.MatchByName) : "(none)";
-            cmd.ReplyToCommand($"  - {prof.Name}  matches: [{aliases}]");
+            string role    = string.IsNullOrWhiteSpace(prof.Role) ? "" : $"  [{prof.Role}]";
+            cmd.ReplyToCommand($"  - {prof.Name}{role}  matches: [{aliases}]");
         }
     }
     // -------------------------------------------------------------------------
@@ -553,6 +605,13 @@ public sealed class ProProfile
     // read a profile and understand the intent without digging through git.
     public string Description { get; set; } = "";
 
+    // Display-only role tag. Used by `pro_list` to remind operators which
+    // bot fills which slot ("Entry rifler", "Lurker", "AWPer", "IGL", ...).
+    // Does NOT influence behavior — the trait flags below do that. The point
+    // is to make a 5-bot roster legible at a glance and to encourage profiles
+    // that double down on a role rather than picking random traits.
+    public string Role { get; set; } = "";
+
     // -- Behavioral flags. All default to false (= "don't touch") so a profile
     //    can opt into only the traits that match the player.
     public bool AlwaysRushing  { get; set; } = false;
@@ -571,6 +630,11 @@ public sealed class ProProfile
     // a rifle in inventory. Does NOT give weapons (would break the economy);
     // pair with a coordinated BotBuy of `ak47` / `m4a1` / `aug` etc.
     public bool RifleOnly            { get; set; } = false;
+
+    // AWPer mirror of RifleOnly. Force-switch back to AWP / Scout whenever
+    // the bot is holding something else. Same no-give policy: requires the
+    // bot to already own the sniper (typically via the buyscript).
+    public bool AwpOnly              { get; set; } = false;
 
     // Counter-strafe at engagement onset, gated by probability so the bot
     // doesn't read as aimbot. On the false->true edge of IsAimingAtEnemy

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -101,6 +101,16 @@ public class ProImitator : BasePlugin
     // Per-tick logic forces knife if currently in window AND not in combat.
     private readonly Dictionary<int, float> _knifeRushUntil = new();
 
+    // V4.1 — Pre/post-plant phase tracker. Set true on EventBombPlanted,
+    // reset on EventRoundStart. Read by the BombFocus block in
+    // ApplyPersonality to flip attacker/defender intent per side:
+    //   pre-plant  : T = attacker, CT = defender
+    //   post-plant : T = defender (hold the bomb tick), CT = attacker (retake/defuse)
+    //
+    // This is the dmarket "post-plant role inversion" — see the V4 banner
+    // comment in ApplyPersonality for the full design.
+    private bool _bombPlanted = false;
+
     // -------------------------------------------------------------------------
     public override void Load(bool hotReload)
     {
@@ -110,6 +120,7 @@ public class ProImitator : BasePlugin
         RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam);
         RegisterEventHandler<EventRoundStart>(OnRoundStart);
         RegisterEventHandler<EventRoundFreezeEnd>(OnRoundFreezeEnd);
+        RegisterEventHandler<EventBombPlanted>(OnBombPlanted);
         RegisterListener<Listeners.OnTick>(OnTick);
 
         // Register commands as plain game console commands (mirrors how the
@@ -255,9 +266,25 @@ public class ProImitator : BasePlugin
     [GameEventHandler]
     public HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
     {
+        // Reset pre/post-plant state for the new round so BombFocus reverts
+        // to its pre-plant intent (T = attacker, CT = defender).
+        _bombPlanted = false;
+
         if (_assigned.Count == 0) return HookResult.Continue;
 
         AddTimer(3.5f, BuyRoleWeapons);
+        return HookResult.Continue;
+    }
+    // -------------------------------------------------------------------------
+    // EventBombPlanted flips the pre/post-plant flag. Combined with BombFocus
+    // in ApplyPersonality, this swaps attacker/defender intent on both sides
+    // — T now needs to defend the plant, CT now needs to retake to defuse.
+    // See dmarket roles guide → "T-side vs CT-side" section for the rationale.
+    // -------------------------------------------------------------------------
+    [GameEventHandler]
+    public HookResult OnBombPlanted(EventBombPlanted @event, GameEventInfo info)
+    {
+        _bombPlanted = true;
         return HookResult.Continue;
     }
     // -------------------------------------------------------------------------
@@ -533,17 +560,25 @@ public class ProImitator : BasePlugin
         //   and the bomb never gets planted. Tactical site execution and
         //   coordinated defence are lost to fragfest behaviour.
         //
-        // What BombFocus does (per-tick, when the trait flag is on):
-        //   T-SIDE: hard-max HurryTimer and clear CheckedHidingSpotCount so
-        //   the bot prioritises moving toward its assigned bombsite over
-        //   stopping for off-angle duels.  This stacks with AlwaysRushing
-        //   when both are set — same field writes, both intents agree.
+        // V4.1 expansion (post-V4 testing feedback):
+        //   - Bomb carrier on T-side now gets an EXTRA-HARD push so they
+        //     don't lurk or wander — they bring the bomb to a site.
+        //   - Pre/post-plant role inversion (dmarket "T-side vs CT-side"
+        //     section): once the bomb is planted, T becomes the defender of
+        //     the plant and CT becomes the attacker who needs to retake.
+        //     BombFocus flips its intent on both sides accordingly.
         //
-        //   CT-SIDE: extend SafeTime so the bot feels "safe at home" near
-        //   its assigned site. It defends the bomb plant rather than
-        //   wandering out toward mid for a long peek. Opposite intent of
-        //   NoSafeTime — these two should NOT both be set on a single
-        //   profile (mutually contradictory).
+        // What BombFocus does per phase:
+        //   PRE-PLANT  T (attacker): HurryTimer maxed, CheckedHidingSpotCount=0
+        //                            Bomb carrier additionally gets IsRunning
+        //                            forced true + SneakTimer/PoliteTimer zeroed.
+        //              CT (defender): SafeTime extended to 8s, holds site.
+        //
+        //   POST-PLANT T (defender): HurryTimer cleared, SafeTime extended to
+        //                            8s, holds the planted site.
+        //              CT (attacker): HurryTimer maxed, CheckedHidingSpotCount=0,
+        //                            retakes toward bomb (engine targets it via
+        //                            its scenario system automatically).
         //
         // What BombFocus deliberately does NOT do:
         //   - Override the engine's bombsite assignment. CS2's nav system
@@ -553,28 +588,36 @@ public class ProImitator : BasePlugin
         //   - Suppress combat. If an enemy actually crosses the bot's path,
         //     normal engagement still happens. This is a *priority* bias,
         //     not a passivity flag.
-        //   - Snapshot bomb-site entities. We rely on the engine knowing
-        //     where its own scenario objectives are; explicit nav-mesh
-        //     traversal from the C# side would be brittle and map-specific.
+        //   - Distribute CTs across A / B / mid. The engine's nav system
+        //     already assigns CT bots to sites at scenario init; forcing a
+        //     specific 2/2/1 split would fight that assignment. If you
+        //     want stronger CT split, deferred future work — would need
+        //     map-specific bombsite position lookup.
         //
         // Tuning notes for future maintainers:
-        //   The two field writes below are the smallest-footprint nudge we
-        //   could find that produced visible behaviour change in playtests.
-        //   If you add more aggressive overrides here (e.g. forcing
-        //   bot.Task or bot.GoalEntity), document the schema fields you
-        //   touch, because BotState may also write them and the load order
-        //   between the two plugins isn't guaranteed.
+        //   The pre/post-plant flag lives in _bombPlanted (set in
+        //   OnBombPlanted, reset in OnRoundStart). The bomb carrier is
+        //   detected by walking the bot's MyWeapons for weapon_c4 — see
+        //   IsCarryingBomb helper. All field writes here are idempotent
+        //   and respect the engine's nav assignment.
         // =====================================================================
         if (prof.BombFocus)
         {
             bool isT  = player.Team == CsTeam.Terrorist;
             bool isCT = player.Team == CsTeam.CounterTerrorist;
 
-            if (isT)
+            // Pre/post-plant phase determines who's the "attacker" (pushing
+            // toward objective) and who's the "defender" (holding ground).
+            //   pre-plant  → T attacks, CT defends
+            //   post-plant → CT attacks (defuse), T defends (the plant)
+            bool isAttacker = (isT && !_bombPlanted) || (isCT && _bombPlanted);
+            bool isDefender = (isCT && !_bombPlanted) || (isT && _bombPlanted);
+
+            if (isAttacker)
             {
-                // Max-out HurryTimer: bot stays in "rush toward goal" mode
-                // for the full round duration. Goal is decided by the
-                // engine's scenario system (the assigned bombsite).
+                // Max HurryTimer: keep moving toward the engine's selected
+                // objective (assigned site pre-plant, planted-bomb position
+                // post-plant for retake).
                 CountdownTimer hurry = bot.HurryTimer;
 
                 ref float hurryDuration  = ref hurry.Duration;
@@ -588,21 +631,56 @@ public class ProImitator : BasePlugin
 
                 // Skip hiding-spot checks while in transit — those are what
                 // makes a bot stop at mid-route corners. The engine still
-                // chooses a hiding spot once it ARRIVES at the site (which
-                // is what defence post-plant needs), this just shortens the
-                // approach phase.
+                // chooses a hiding spot once it ARRIVES at the objective.
                 ref int checkedHidingSpotCount = ref bot.CheckedHidingSpotCount;
                 checkedHidingSpotCount         = 0;
             }
-            else if (isCT)
+            else if (isDefender)
             {
                 // Extend SafeTime: bot stays in "safe at home" perception
                 // longer, meaning it's less likely to peek out for distant
-                // duels. The engine still triggers full alertness once an
-                // enemy is actually nearby; this just stops the early-round
-                // mid-rush behaviour CTs sometimes show.
+                // duels. Pre-plant CTs hold their site; post-plant Ts hold
+                // the planted bomb. Same mechanism for both phases.
                 ref float safeTime = ref bot.SafeTime;
                 safeTime           = 8.0f;
+
+                // Clear HurryTimer so the bot stops trying to advance.
+                // Without this, a T who was AlwaysRushing pre-plant would
+                // keep wandering away from the planted bomb post-plant.
+                CountdownTimer hurry = bot.HurryTimer;
+                ref float hurryDuration = ref hurry.Duration;
+                hurryDuration = 0.0f;
+                ref float hurryTimestamp = ref hurry.Timestamp;
+                hurryTimestamp = 0.0f;
+            }
+
+            // Bomb-carrier extra push (pre-plant T only — post-plant the
+            // bomb is on the ground, no carrier). The bomb-carrier role is
+            // strategically the most important on T-side: they need to GET
+            // TO A SITE and PLANT, not lurk or trade.
+            if (isT && !_bombPlanted && IsCarryingBomb(pawn))
+            {
+                // Force the bot to run (no walking, no crouch-stand).
+                ref bool isRunning = ref bot.IsRunning;
+                isRunning = true;
+
+                // Zero out every "wait" timer so nothing delays the bomb-
+                // carrier — they're the round, they don't lurk, they don't
+                // wait for trades, they don't pause for a sneak peek.
+                CountdownTimer sneak = bot.SneakTimer;
+                ref float sneakDuration  = ref sneak.Duration;
+                sneakDuration            = 0.0f;
+                ref float sneakTimestamp = ref sneak.Timestamp;
+                sneakTimestamp           = 0.0f;
+
+                CountdownTimer polite = bot.PoliteTimer;
+                ref float politeDuration  = ref polite.Duration;
+                politeDuration            = 0.0f;
+                ref float politeTimestamp = ref polite.Timestamp;
+                politeTimestamp           = 0.0f;
+
+                ref bool waitingBehindFriend = ref bot.IsWaitingBehindFriend;
+                waitingBehindFriend = false;
             }
         }
 
@@ -682,10 +760,26 @@ public class ProImitator : BasePlugin
             bool holdingKnife = activeWeapon != null && activeWeapon.StartsWith("weapon_knife");
             if (!holdingKnife)
             {
+                // V4.1 — we now fire BOTH command paths every tick because
+                // playtests showed the client-only `slot3` was getting
+                // consistently outraced by the bot AI's internal weapon
+                // selection (which runs every server tick too).
+                //
+                //   1. `slot3`        — client-side slot selection. Cheap,
+                //                       maps to whatever knife the bot has.
+                //   2. `use weapon_knife` via Server.ExecuteCommand —
+                //                       server-side path through the engine's
+                //                       weapon-use logic. Different priority
+                //                       than slot3 in the command queue, so
+                //                       at least one of the two should win
+                //                       the race against the AI's auto-select
+                //                       on any given tick.
+                //
+                // No cooldown: re-issue every tick until activeWeapon
+                // actually becomes a knife. Once holdingKnife=true the loop
+                // stops issuing.
                 NativeAPI.IssueClientCommand((int)player.Slot, "slot3");
-                // Intentionally no cooldown: re-issue every tick until the
-                // bot is actually on knife. Once holdingKnife=true the issue
-                // stops naturally.
+                Server.ExecuteCommand($"bot_command \"{player.PlayerName}\" use weapon_knife");
             }
         }
 
@@ -735,6 +829,25 @@ public class ProImitator : BasePlugin
                 }
             }
         }
+    }
+    // -------------------------------------------------------------------------
+    // Does the bot's inventory contain the C4? Used by BombFocus to give the
+    // bomb carrier an extra push toward planting (no lurk, no wait, run).
+    // The CS2 C4 designer name is "weapon_c4"; if it's in MyWeapons the bot
+    // is carrying it (only one player per T-side has it at a time).
+    // -------------------------------------------------------------------------
+    private static bool IsCarryingBomb(CCSPlayerPawn pawn)
+    {
+        var weapons = pawn.WeaponServices?.MyWeapons;
+        if (weapons == null) return false;
+
+        foreach (var handle in weapons)
+        {
+            var w = handle.Value;
+            if (w == null || !w.IsValid) continue;
+            if (w.DesignerName == "weapon_c4") return true;
+        }
+        return false;
     }
     // -------------------------------------------------------------------------
     // Is any alive opposing-team player within maxUnits of selfPawn? Used by

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -249,13 +249,9 @@ public class ProImitator : BasePlugin
             // Rifler wins by reading first.
             if (prof.Rifler)
             {
-                // Both AK and M4A1 cost 2700 in current CS2 (Valve aligned
-                // the prices in a recent update). Note: BotBuy.cs still has
-                // M4A1 at 2900 in its price table — that's a stale BotBuy
-                // bug, separate from ProImitator. We use the engine's real
-                // current price so our deduction matches what CS2 thinks.
+                // Prices mirror BotBuy.cs price table (AK 2700, M4A4 2900).
                 string preferred = isT ? "weapon_ak47" : "weapon_m4a1";
-                int    price     = 2700;
+                int    price     = isT ? 2700        : 2900;
                 TryBuyRoleWeapon(player, pawn, preferred, price);
             }
             else if (prof.AWPer)
@@ -734,11 +730,11 @@ public sealed class ProProfile
     public bool NoApproachPause      { get; set; } = false;
 
     // "I main rifles." Two effects:
-    //   1. At round-freeze: if the bot has the AK / M4A1 full price (2700,
-    //      same for both in current CS2) in cash AND doesn't already own
-    //      the preferred rifle, buy it. Any other big primary the engine
-    //      gave them is dropped (sunk cost). No refunds, no fake money —
-    //      strict "buy iff you have the cash".
+    //   1. At round-freeze: if the bot has the full price in cash (AK 2700
+    //      for T, M4A4 2900 for CT) AND doesn't already own the preferred
+    //      rifle, buy it. Any other big primary the engine gave them is
+    //      dropped (sunk cost). No refunds, no fake money — strict "buy
+    //      iff you have the cash".
     //   2. Per tick: if the bot is holding a non-rifle but already owns one,
     //      `use weapon_*` switches them back to it.
     public bool Rifler               { get; set; } = false;

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -94,12 +94,10 @@ public class ProImitator : BasePlugin
     private readonly Dictionary<int, float> _counterStrafeUntil = new();
     private const float CounterStrafeDurationSec = 0.12f;
 
-    // KnifeRush state. The pro round-opener: hold knife to gain ~20% movement
-    // speed (260 u/s vs 215 rifle / 200 AWP) during the peaceful rush phase,
-    // switch to weapon ~3s before expected contact. We track until-when the
-    // bot should hold knife (per-profile KnifeRushSec, set in OnRoundFreezeEnd).
-    // Per-tick logic forces knife if currently in window AND not in combat.
-    private readonly Dictionary<int, float> _knifeRushUntil = new();
+    // V4.8 — KnifeRush is now purely distance-gated. No time window; the bot
+    // holds the knife whenever no alive opponent is within 1500u. As soon as
+    // someone enters that radius, the Rifler / AWPer per-tick switch pulls
+    // their primary. State dict + OnRoundFreezeEnd setup removed.
 
     // V4.1 — Pre/post-plant phase tracker. Set true on EventBombPlanted,
     // reset on EventRoundStart. Read by the BombFocus block in
@@ -148,7 +146,6 @@ public class ProImitator : BasePlugin
         RegisterEventHandler<EventPlayerSpawn>(OnPlayerSpawn);
         RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam);
         RegisterEventHandler<EventRoundStart>(OnRoundStart);
-        RegisterEventHandler<EventRoundFreezeEnd>(OnRoundFreezeEnd);
         RegisterEventHandler<EventBombPlanted>(OnBombPlanted);
         RegisterListener<Listeners.OnTick>(OnTick);
 
@@ -244,7 +241,6 @@ public class ProImitator : BasePlugin
             _lastWeaponSwitchAt.Remove(player.Slot);
             _wasAimingAtEnemy.Remove(player.Slot);
             _counterStrafeUntil.Remove(player.Slot);
-            _knifeRushUntil.Remove(player.Slot);
             _carrierRunFlipAt.Remove(player.Slot);
             _carrierRunDecision.Remove(player.Slot);
             _logKnifeForceWasActive.Remove(player.Slot);
@@ -263,23 +259,8 @@ public class ProImitator : BasePlugin
     // holding knife while the bot is rooted in spawn. We want the knife hold
     // to start the instant the bot can actually move.
     // -------------------------------------------------------------------------
-    [GameEventHandler]
-    public HookResult OnRoundFreezeEnd(EventRoundFreezeEnd @event, GameEventInfo info)
-    {
-        if (_assigned.Count == 0) return HookResult.Continue;
-
-        float now = Server.CurrentTime;
-        int knifeRushCount = 0;
-        foreach (var kvp in _assigned)
-        {
-            if (!kvp.Value.KnifeRush) continue;
-            _knifeRushUntil[kvp.Key] = now + kvp.Value.KnifeRushSec;
-            knifeRushCount++;
-            DebugBroadcast($"knife rush opened slot={kvp.Key} {kvp.Value.Name} +{kvp.Value.KnifeRushSec:F1}s");
-        }
-        DebugBroadcast($"OnRoundFreezeEnd: {_assigned.Count} profiled, {knifeRushCount} knife rush windows");
-        return HookResult.Continue;
-    }
+    // V4.8 — OnRoundFreezeEnd handler removed. Was only used to open per-bot
+    // KnifeRush time windows; now KnifeRush is distance-only, no setup needed.
     // -------------------------------------------------------------------------
     // Role-buy at round-freeze. Strict rule:
     //   if bot has cash >= role weapon's FULL price (no refund credits,
@@ -854,37 +835,20 @@ public class ProImitator : BasePlugin
         }
 
         // ---------------------------------------------------------------------
-        // KnifeRush: hold knife during the peaceful early-round rush phase
-        // (faster movement: 260 u/s vs 215 rifle / 200 AWP) and switch to the
-        // role weapon once a real duel is imminent. Window was opened in
-        // OnRoundFreezeEnd.
+        // KnifeRush (V4.8 distance-only): hold knife whenever no alive
+        // opponent is within KnifeRushCombatRangeUnits (1500u), pull the
+        // role weapon the instant someone enters that radius. No time
+        // window — the bot will repeatedly hold knife mid-round during
+        // long traversals between angles, then weapon-up on every threat
+        // approach. Realistic pro movement pattern across all sides.
         //
-        // "Imminent duel" detection uses two signals:
-        //   - bot.IsAimingAtEnemy: the bot's AI has locked onto an enemy.
-        //     This is necessary but NOT sufficient — the bot AI sees long
-        //     sightlines, and at round-start on Dust2 a CT can lock onto a
-        //     T 3000 units away and we don't want that to break the knife
-        //     rush across the entire map.
-        //   - nearest enemy distance: an alive enemy of the opposite team
-        //     must be within KnifeRushCombatRangeUnits (~1500u, roughly mid-
-        //     Dust2 length). Below that we treat it as a real duel and pull
-        //     the role weapon.
-        //
-        // Once we decide to force knife, we re-issue `slot3` EVERY tick (no
-        // cooldown) until activeWeapon actually becomes a knife — the engine
-        // bot AI tries to re-pull primary aggressively and we need to outpace
-        // it. `slot3` is more reliable than `use weapon_*` for knives because
-        // the designer name varies by team / skin (weapon_knife_t, etc).
+        // The IsAimingAtEnemy AI gate was removed in V4.8 — it was a
+        // hedge for the previous time-window approach. Now we trust the
+        // pure spatial check: if a threat is geometrically close, weapon
+        // up, regardless of whether the bot has visually "spotted" them.
         // ---------------------------------------------------------------------
-        bool inKnifeRush = _knifeRushUntil.TryGetValue(player.Slot, out float kRushUntil)
-                        && now < kRushUntil;
-
-        bool inDuel = false;
-        if (inKnifeRush && bot.IsAimingAtEnemy)
-        {
-            inDuel = NearestEnemyWithinUnits(player, pawn, 1500f);
-        }
-        bool forceKnife = inKnifeRush && !inDuel;
+        bool forceKnife = prof.KnifeRush
+                       && !NearestEnemyWithinUnits(player, pawn, 1500f);
 
         // Edge-detected log: knife force START / END (only when state flips).
         {
@@ -1346,15 +1310,18 @@ public sealed class ProProfile
     // bot oscillates between alert and relaxed.
     public bool BombFocus { get; set; } = false;
 
-    // KnifeRush: hold knife during the peaceful early-round rush so the bot
-    // gets the knife's movement bonus (~20% faster: 260 u/s vs 215 rifle,
-    // 200 AWP). Switches back to the role weapon either after KnifeRushSec
-    // elapses OR the moment the bot enters a duel (whichever comes first).
+    // KnifeRush (V4.8 distance-only): hold knife to gain ~20% movement
+    // speed (260 u/s vs 215 rifle / 200 AWP) whenever no alive opponent
+    // is within 1500u. As soon as a threat enters that radius, the Rifler
+    // / AWPer per-tick switch pulls the role weapon.
     //
-    // Real pros do this all the time on de_*: jog out with the knife,
-    // switch ~3s before expected contact. The "expected contact" varies by
-    // map and role — entry T sees enemies sooner than a CT AWPer holding
-    // a long angle — so KnifeRushSec is per-profile.
+    // No time window — the bot will repeatedly hold knife during long
+    // mid-round traversals between angles, weapon-up on every threat
+    // approach. Real pro movement pattern across both sides.
+    //
+    // (V4.7 and earlier had a per-profile KnifeRushSec time window. The
+    // field is deserialised-but-ignored now for backward compat with
+    // old JSON files; safe to omit from new profiles.)
     public bool  KnifeRush    { get; set; } = false;
-    public float KnifeRushSec { get; set; } = 5.0f;
+    public float KnifeRushSec { get; set; } = 0.0f;  // deprecated, ignored
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -560,39 +560,48 @@ public class ProImitator : BasePlugin
         //   and the bomb never gets planted. Tactical site execution and
         //   coordinated defence are lost to fragfest behaviour.
         //
-        // V4.1 expansion (post-V4 testing feedback):
-        //   - Bomb carrier on T-side now gets an EXTRA-HARD push so they
-        //     don't lurk or wander — they bring the bomb to a site.
-        //   - Pre/post-plant role inversion (dmarket "T-side vs CT-side"
-        //     section): once the bomb is planted, T becomes the defender of
-        //     the plant and CT becomes the attacker who needs to retake.
-        //     BombFocus flips its intent on both sides accordingly.
+        // V4.1 added: pre/post-plant inversion + bomb carrier extra push.
         //
-        // What BombFocus does per phase:
-        //   PRE-PLANT  T (attacker): HurryTimer maxed, CheckedHidingSpotCount=0
-        //                            Bomb carrier additionally gets IsRunning
-        //                            forced true + SneakTimer/PoliteTimer zeroed.
-        //              CT (defender): SafeTime extended to 8s, holds site.
+        // V4.2 tone-down (current): V4.1's effects were too heavy in play-
+        // tests — bots looked like "locomotives" running through cover.
+        // The fix is to keep the strategic intent (push site / hold site /
+        // invert post-plant) but make every field write a NUDGE rather than
+        // an override:
+        //   - HurryTimer Duration dropped from 600s (perpetual max) to 10s
+        //     (still refreshed each tick, but with a short "horizon" the
+        //     engine pathing code can interpret as bias, not absolute).
+        //   - CheckedHidingSpotCount=0 REMOVED. That was the line that made
+        //     bots ignore cover. Now the engine's hiding-spot checks run
+        //     normally, just with HurryTimer favouring the objective route.
+        //   - Defender SafeTime dropped from 8s to 3s. Less jumpy on peeks
+        //     but still reacts to clear threats.
+        //   - Bomb carrier no longer gets IsRunning=true and the wait-timer
+        //     wipe. They keep strategic behaviour (cover, peeks, patience)
+        //     and only get a slightly longer hurry horizon (20s vs 10s for
+        //     other Ts) as the "slightly more site-focused than teammates"
+        //     bias the user asked for.
         //
-        //   POST-PLANT T (defender): HurryTimer cleared, SafeTime extended to
-        //                            8s, holds the planted site.
-        //              CT (attacker): HurryTimer maxed, CheckedHidingSpotCount=0,
-        //                            retakes toward bomb (engine targets it via
-        //                            its scenario system automatically).
+        // What BombFocus does per phase (V4.2 values):
+        //   PRE-PLANT  T (attacker):  HurryTimer.Duration = 10s, refreshed
+        //                             Bomb carrier: HurryTimer.Duration = 20s
+        //              CT (defender): SafeTime = 3s, refreshed
+        //
+        //   POST-PLANT T (defender):  SafeTime = 3s, refreshed
+        //              CT (attacker): HurryTimer.Duration = 10s, refreshed
         //
         // What BombFocus deliberately does NOT do:
         //   - Override the engine's bombsite assignment. CS2's nav system
         //     decides which bot is "attacker of A vs attacker of B" at
         //     scenario init; we don't touch that. We just nudge the timer
         //     biases so the engine's existing plan executes more cleanly.
-        //   - Suppress combat. If an enemy actually crosses the bot's path,
-        //     normal engagement still happens. This is a *priority* bias,
-        //     not a passivity flag.
+        //   - Suppress combat or use of cover. The bot still pauses at
+        //     hiding spots, takes peeks, uses utility — BombFocus is a
+        //     destination bias, not a behaviour replacement.
         //   - Distribute CTs across A / B / mid. The engine's nav system
         //     already assigns CT bots to sites at scenario init; forcing a
-        //     specific 2/2/1 split would fight that assignment. If you
-        //     want stronger CT split, deferred future work — would need
-        //     map-specific bombsite position lookup.
+        //     specific 2/2/1 split would fight that assignment. Deferred
+        //     future work — would need map-specific bombsite position
+        //     lookup.
         //
         // Tuning notes for future maintainers:
         //   The pre/post-plant flag lives in _bombPlanted (set in
@@ -600,6 +609,12 @@ public class ProImitator : BasePlugin
         //   detected by walking the bot's MyWeapons for weapon_c4 — see
         //   IsCarryingBomb helper. All field writes here are idempotent
         //   and respect the engine's nav assignment.
+        //
+        //   When tuning numbers: keep them small. V4.1 used 600s and it
+        //   looked terrible. V4.2 uses 10-20s and looks like real CS. If
+        //   you need more punch, prefer adjusting the AlwaysRushing /
+        //   NoSafeTime traits in profiles rather than amplifying these
+        //   nudges — those are the heavy levers, BombFocus is the trim.
         // =====================================================================
         if (prof.BombFocus)
         {
@@ -615,72 +630,53 @@ public class ProImitator : BasePlugin
 
             if (isAttacker)
             {
-                // Max HurryTimer: keep moving toward the engine's selected
-                // objective (assigned site pre-plant, planted-bomb position
-                // post-plant for retake).
+                // Subtle hurry bias: 10s horizon refreshed each tick. Bot
+                // prioritises the objective route but the engine still
+                // honours hiding-spot pauses, peeks, and cover usage. We
+                // deliberately do NOT clear CheckedHidingSpotCount here —
+                // that V4.1 line was the "locomotive" behaviour the user
+                // flagged as too extreme.
                 CountdownTimer hurry = bot.HurryTimer;
 
                 ref float hurryDuration  = ref hurry.Duration;
-                hurryDuration            = 600.0f;
+                hurryDuration            = 10.0f;
 
                 ref float hurryTimestamp = ref hurry.Timestamp;
-                hurryTimestamp           = now + 600.0f;
+                hurryTimestamp           = now + 10.0f;
 
                 ref float hurryTimescale = ref hurry.Timescale;
                 hurryTimescale           = 1.0f;
-
-                // Skip hiding-spot checks while in transit — those are what
-                // makes a bot stop at mid-route corners. The engine still
-                // chooses a hiding spot once it ARRIVES at the objective.
-                ref int checkedHidingSpotCount = ref bot.CheckedHidingSpotCount;
-                checkedHidingSpotCount         = 0;
             }
             else if (isDefender)
             {
-                // Extend SafeTime: bot stays in "safe at home" perception
-                // longer, meaning it's less likely to peek out for distant
-                // duels. Pre-plant CTs hold their site; post-plant Ts hold
-                // the planted bomb. Same mechanism for both phases.
+                // Subtle hold bias: SafeTime 3s (V4.1 used 8s). Bot stays
+                // slightly less jumpy on early-round peeks but still
+                // reacts to clear threats. We deliberately do NOT clear
+                // HurryTimer — the engine should keep its natural ability
+                // to chase a wounded enemy or rotate when needed.
                 ref float safeTime = ref bot.SafeTime;
-                safeTime           = 8.0f;
-
-                // Clear HurryTimer so the bot stops trying to advance.
-                // Without this, a T who was AlwaysRushing pre-plant would
-                // keep wandering away from the planted bomb post-plant.
-                CountdownTimer hurry = bot.HurryTimer;
-                ref float hurryDuration = ref hurry.Duration;
-                hurryDuration = 0.0f;
-                ref float hurryTimestamp = ref hurry.Timestamp;
-                hurryTimestamp = 0.0f;
+                safeTime           = 3.0f;
             }
 
-            // Bomb-carrier extra push (pre-plant T only — post-plant the
-            // bomb is on the ground, no carrier). The bomb-carrier role is
-            // strategically the most important on T-side: they need to GET
-            // TO A SITE and PLANT, not lurk or trade.
+            // Bomb carrier on pre-plant T-side: slightly more site-focused
+            // than the rest of the T side, but still strategic. They keep
+            // strategic behaviour intact — they use cover, take peeks, wait
+            // for trades — they just have a longer hurry horizon (20s vs
+            // 10s for the other Ts) so they're less likely to peel back to
+            // lurk or back-trade. The V4.1 carrier hack (force IsRunning,
+            // wipe SneakTimer / PoliteTimer / IsWaitingBehindFriend) was
+            // removed: it made the carrier behave like a hold-W zombie
+            // instead of a pro who knows the bomb still needs to be brought
+            // to site safely.
             if (isT && !_bombPlanted && IsCarryingBomb(pawn))
             {
-                // Force the bot to run (no walking, no crouch-stand).
-                ref bool isRunning = ref bot.IsRunning;
-                isRunning = true;
+                CountdownTimer hurry = bot.HurryTimer;
 
-                // Zero out every "wait" timer so nothing delays the bomb-
-                // carrier — they're the round, they don't lurk, they don't
-                // wait for trades, they don't pause for a sneak peek.
-                CountdownTimer sneak = bot.SneakTimer;
-                ref float sneakDuration  = ref sneak.Duration;
-                sneakDuration            = 0.0f;
-                ref float sneakTimestamp = ref sneak.Timestamp;
-                sneakTimestamp           = 0.0f;
+                ref float hurryDuration  = ref hurry.Duration;
+                hurryDuration            = 20.0f;
 
-                CountdownTimer polite = bot.PoliteTimer;
-                ref float politeDuration  = ref polite.Duration;
-                politeDuration            = 0.0f;
-                ref float politeTimestamp = ref polite.Timestamp;
-                politeTimestamp           = 0.0f;
-
-                ref bool waitingBehindFriend = ref bot.IsWaitingBehindFriend;
-                waitingBehindFriend = false;
+                ref float hurryTimestamp = ref hurry.Timestamp;
+                hurryTimestamp           = now + 20.0f;
             }
         }
 

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -249,9 +249,13 @@ public class ProImitator : BasePlugin
             // Rifler wins by reading first.
             if (prof.Rifler)
             {
-                // Prices mirror BotBuy.cs (AK 2700, M4A1 2900).
+                // Both AK and M4A1 cost 2700 in current CS2 (Valve aligned
+                // the prices in a recent update). Note: BotBuy.cs still has
+                // M4A1 at 2900 in its price table — that's a stale BotBuy
+                // bug, separate from ProImitator. We use the engine's real
+                // current price so our deduction matches what CS2 thinks.
                 string preferred = isT ? "weapon_ak47" : "weapon_m4a1";
-                int    price     = isT ? 2700        : 2900;
+                int    price     = 2700;
                 TryBuyRoleWeapon(player, pawn, preferred, price);
             }
             else if (prof.AWPer)
@@ -730,10 +734,11 @@ public sealed class ProProfile
     public bool NoApproachPause      { get; set; } = false;
 
     // "I main rifles." Two effects:
-    //   1. At round-freeze: if the bot has the AK / M4 full price (2700/2900)
-    //      in cash AND doesn't already own the preferred rifle, buy it. Any
-    //      other big primary the engine gave them is dropped (sunk cost). No
-    //      refunds, no fake money — strict "buy iff you have the cash".
+    //   1. At round-freeze: if the bot has the AK / M4A1 full price (2700,
+    //      same for both in current CS2) in cash AND doesn't already own
+    //      the preferred rifle, buy it. Any other big primary the engine
+    //      gave them is dropped (sunk cost). No refunds, no fake money —
+    //      strict "buy iff you have the cash".
     //   2. Per tick: if the bot is holding a non-rifle but already owns one,
     //      `use weapon_*` switches them back to it.
     public bool Rifler               { get; set; } = false;

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -38,9 +38,23 @@ namespace ProImitator;
 public class ProImitator : BasePlugin
 {
     public override string ModuleName        => "Pro-Imitator";
-    public override string ModuleVersion     => "0.1.0";
+    public override string ModuleVersion     => "0.2.0";
     public override string ModuleAuthor      => "Contribution to ed0ard/CS2-Bot-Improver";
     public override string ModuleDescription => "Per-bot personality presets so the donk bot plays like donk";
+
+    // Weapon classifier used by NoCrouchWithRifle. Anything not in this set
+    // (pistols, SMGs, snipers, shotguns) keeps the BotState default crouch
+    // behavior so a profiled bot still crouches with e.g. a Deagle pop.
+    private static readonly HashSet<string> RifleDesignerNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "weapon_ak47",
+        "weapon_m4a1",
+        "weapon_m4a1_silencer",
+        "weapon_sg556",      // Krieg
+        "weapon_aug",
+        "weapon_galilar",
+        "weapon_famas",
+    };
 
     // Loaded profiles, keyed by their JSON 'Name' (lowercased) for de-dup.
     private readonly Dictionary<string, ProProfile> _profiles = new();
@@ -187,7 +201,10 @@ public class ProImitator : BasePlugin
             var bot = pawn.Bot;
             if (bot == null) continue;
 
-            ApplyPersonality(bot, prof, now);
+            // Weapon name is needed by a couple of traits. Cheap to read once.
+            string? activeWeapon = pawn.WeaponServices?.ActiveWeapon?.Value?.DesignerName;
+
+            ApplyPersonality(bot, pawn, prof, now, activeWeapon);
         }
     }
     // -------------------------------------------------------------------------
@@ -196,7 +213,7 @@ public class ProImitator : BasePlugin
     // Each block is opt-in; profiles can mix-and-match. Anything not listed in
     // a profile is left untouched (BotState's generic improvements still apply).
     // -------------------------------------------------------------------------
-    private static void ApplyPersonality(CCSBot bot, ProProfile prof, float now)
+    private static void ApplyPersonality(CCSBot bot, CCSPlayerPawn pawn, ProProfile prof, float now, string? activeWeapon)
     {
         if (prof.AlwaysRushing)
         {
@@ -278,6 +295,54 @@ public class ProImitator : BasePlugin
 
             ref float panicTimescale = ref panicTimer.Timescale;
             panicTimescale = 1.0f;
+        }
+
+        // ---------------------------------------------------------------------
+        // V2 visual-identity traits. These are the markers that make a
+        // profiled bot READ as "X player" to a spectator rather than just
+        // "generic aggressive bot".
+        // ---------------------------------------------------------------------
+
+        if (prof.NoCrouchWithRifle)
+        {
+            // donk's most iconic visual: stand-spray with rifles instead of
+            // the 50% crouch chance BotState picks for AK/M4 classes (see
+            // BotState.OnWeaponFire). Forcing IsCrouching=false every tick
+            // overrides BotState's per-shot decision when the active weapon
+            // is a rifle. Non-rifle weapons keep the BotState default so
+            // pistol-pop scenarios still look natural.
+            if (activeWeapon != null && RifleDesignerNames.Contains(activeWeapon))
+            {
+                ref bool isCrouching = ref bot.IsCrouching;
+                isCrouching = false;
+            }
+        }
+
+        if (prof.NeverWaitsBetweenShots)
+        {
+            // Zero the "next allowed shot" timer so the AI never throttles
+            // its fire rate between bursts. BotAI has memory patches in the
+            // same family (AttackState_SkipFireRateCheck) for all bots; this
+            // is the schema-level equivalent re-applied each tick.
+            ref float fireWeaponTimestamp = ref bot.FireWeaponTimestamp;
+            fireWeaponTimestamp = 0.0f;
+
+            ref bool isRapidFiring = ref bot.IsRapidFiring;
+            isRapidFiring = true;
+        }
+
+        if (prof.NoApproachPause)
+        {
+            // ApproachPoint pauses are the little "wait at the corner" beats
+            // a bot does when traversing a path. Hyper-aggressive players
+            // skip them — they're already committed before reaching the
+            // angle. Zeroing InhibitLookAroundTimestamp lets the aim system
+            // immediately scan and engage on arrival.
+            ref float inhibitLookAroundTimestamp = ref bot.InhibitLookAroundTimestamp;
+            inhibitLookAroundTimestamp = 0.0f;
+
+            ref int checkedHidingSpotCount = ref bot.CheckedHidingSpotCount;
+            checkedHidingSpotCount = 0;
         }
     }
     // -------------------------------------------------------------------------
@@ -381,4 +446,10 @@ public sealed class ProProfile
     public bool NeverPolite    { get; set; } = false;
     public bool NoSafeTime     { get; set; } = false;
     public bool NoPanic        { get; set; } = false;
+
+    // -- V2: visual-identity traits that make the bot READ as the specific
+    //    player rather than just "another aggressive bot".
+    public bool NoCrouchWithRifle    { get; set; } = false;
+    public bool NeverWaitsBetweenShots { get; set; } = false;
+    public bool NoApproachPause      { get; set; } = false;
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -69,6 +69,16 @@ public class ProImitator : BasePlugin
     private readonly Dictionary<int, float> _lastWeaponSwitchAt = new();
     private const float WeaponSwitchCooldownSec = 0.5f;
 
+    // CounterStrafes state. The pro behavior we're simulating: bot rushes,
+    // first sees an enemy (IsAimingAtEnemy transitions false -> true), then
+    // we kill its lateral velocity for ~120ms so the first tap lands with
+    // CS's full-accuracy "standing still" penalty applied. Real human pros
+    // do this via A+D-tap inputs that cancel momentum within 1-3 frames; here
+    // we just zero the schema field, same observable effect.
+    private readonly Dictionary<int, bool> _wasAimingAtEnemy = new();
+    private readonly Dictionary<int, float> _counterStrafeUntil = new();
+    private const float CounterStrafeDurationSec = 0.12f;
+
     // -------------------------------------------------------------------------
     public override void Load(bool hotReload)
     {
@@ -159,6 +169,8 @@ public class ProImitator : BasePlugin
         {
             _assigned.Remove(player.Slot);
             _lastWeaponSwitchAt.Remove(player.Slot);
+            _wasAimingAtEnemy.Remove(player.Slot);
+            _counterStrafeUntil.Remove(player.Slot);
         }
 
         return HookResult.Continue;
@@ -352,6 +364,41 @@ public class ProImitator : BasePlugin
             checkedHidingSpotCount = 0;
         }
 
+        if (prof.CounterStrafes)
+        {
+            // Engagement-onset velocity kill. The pro tap-shot rhythm:
+            //   rush -> see enemy -> *brief stop* -> first tap (accurate) -> resume
+            //
+            // We detect the false->true edge of IsAimingAtEnemy and schedule
+            // ~120ms of zeroed lateral velocity. During that window, even if
+            // the bot's pathfinder is still trying to push forward, the
+            // velocity write each tick keeps it pinned in place.
+            //
+            // Once the window expires, normal movement resumes — so this
+            // doesn't turn donk into a stationary turret in a sustained
+            // spray, just gives him the iconic mid-rush counter-strafe stop
+            // on EVERY new engagement.
+            bool isAimingAtEnemy = bot.IsAimingAtEnemy;
+            bool wasAiming = _wasAimingAtEnemy.GetValueOrDefault(player.Slot, false);
+
+            if (isAimingAtEnemy && !wasAiming)
+                _counterStrafeUntil[player.Slot] = now + CounterStrafeDurationSec;
+
+            if (_counterStrafeUntil.TryGetValue(player.Slot, out float until) && now < until)
+            {
+                // Only stomp velocity if the bot is actually moving — avoids
+                // a useless SetStateChanged when he's already at rest.
+                if (MathF.Abs(pawn.AbsVelocity.X) > 1f || MathF.Abs(pawn.AbsVelocity.Y) > 1f)
+                {
+                    pawn.AbsVelocity.X = 0f;
+                    pawn.AbsVelocity.Y = 0f;
+                    Utilities.SetStateChanged(pawn, "CBaseEntity", "m_vecAbsVelocity");
+                }
+            }
+
+            _wasAimingAtEnemy[player.Slot] = isAimingAtEnemy;
+        }
+
         if (prof.RifleOnly)
         {
             // Force-prefer rifles when the bot is holding something else but
@@ -513,4 +560,11 @@ public sealed class ProProfile
     // a rifle in inventory. Does NOT give weapons (would break the economy);
     // pair with a coordinated BotBuy of `ak47` / `m4a1` / `aug` etc.
     public bool RifleOnly            { get; set; } = false;
+
+    // Counter-strafe at engagement onset. When the bot first sees an enemy
+    // (IsAimingAtEnemy transitions false->true), zero its lateral velocity
+    // for ~120ms so the first tap-shot lands with full standing-still
+    // accuracy. Pro-rusher signature; without this the bot run-and-guns and
+    // ALWAYS sprays which is visually wrong.
+    public bool CounterStrafes       { get; set; } = false;
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -101,6 +101,7 @@ public class ProImitator : BasePlugin
 
         RegisterEventHandler<EventPlayerSpawn>(OnPlayerSpawn);
         RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam);
+        RegisterEventHandler<EventRoundStart>(OnRoundStart);
         RegisterListener<Listeners.OnTick>(OnTick);
 
         // Register commands as plain game console commands (mirrors how the
@@ -197,6 +198,109 @@ public class ProImitator : BasePlugin
         }
 
         return HookResult.Continue;
+    }
+    // -------------------------------------------------------------------------
+    // Role-buy at round-freeze. Strict rule:
+    //   if bot has cash >= role weapon's FULL price (no refund credits,
+    //   no swap math), buy it.
+    //
+    // That's the entire "full-buy phase" detector: having the price in cash
+    // proves we're in a buy round for this bot. Below the price -> we're on
+    // eco / semi-buy / save and ProImitator stays out of it.
+    //
+    // No fake money anywhere: we never refund the bot's existing weapon and
+    // credit them for it. If the bot already owns a different big primary
+    // (engine bought him an M4 when his profile is AWPer, or a Galil when
+    // his profile is Rifler), we drop that weapon WITHOUT refund and pay
+    // the role weapon's full price. The dropped weapon's cost is sunk —
+    // the bot clearly had the headroom because they still had the role
+    // price in cash AFTER paying for the original.
+    //
+    // 3.5s delay after EventRoundStart so BotBuy's longest timer (3.0s) has
+    // settled. Freeze is typically 15-20s, so we're well inside the buy
+    // window for GiveNamedItem to take effect.
+    // -------------------------------------------------------------------------
+    [GameEventHandler]
+    public HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
+    {
+        if (_assigned.Count == 0) return HookResult.Continue;
+
+        AddTimer(3.5f, BuyRoleWeapons);
+        return HookResult.Continue;
+    }
+    // -------------------------------------------------------------------------
+    private void BuyRoleWeapons()
+    {
+        foreach (var kvp in _assigned)
+        {
+            var player = Utilities.GetPlayerFromSlot(kvp.Key);
+            if (player == null || !player.IsValid || !player.IsBot) continue;
+            if (player.InGameMoneyServices == null) continue;
+
+            var pawn = player.PlayerPawn.Value;
+            if (pawn == null || !pawn.IsValid) continue;
+
+            var prof = kvp.Value;
+            bool isT  = player.Team == CsTeam.Terrorist;
+            bool isCT = player.Team == CsTeam.CounterTerrorist;
+            if (!isT && !isCT) continue;
+
+            // Rifler / AWPer should be mutually exclusive; if both true,
+            // Rifler wins by reading first.
+            if (prof.Rifler)
+            {
+                // Prices mirror BotBuy.cs (AK 2700, M4A1 2900).
+                string preferred = isT ? "weapon_ak47" : "weapon_m4a1";
+                int    price     = isT ? 2700        : 2900;
+                TryBuyRoleWeapon(player, pawn, preferred, price);
+            }
+            else if (prof.AWPer)
+            {
+                TryBuyRoleWeapon(player, pawn, "weapon_awp", 4750);
+            }
+        }
+    }
+    // -------------------------------------------------------------------------
+    private static void TryBuyRoleWeapon(
+        CCSPlayerController player,
+        CCSPlayerPawn pawn,
+        string preferred,
+        int price)
+    {
+        // Already holds the role weapon? Done.
+        if (HasWeapon(pawn, preferred)) return;
+
+        // Strict affordability — bot must have the FULL price in cash. No
+        // counting "refund credits" from an existing weapon. This is the
+        // single gate that prevents the "ZywOo got AWP without the money"
+        // bug from earlier swap-based attempts.
+        if (player.InGameMoneyServices!.Account < price) return;
+
+        // Drop any existing big primary that would conflict (engine bought
+        // them the "wrong" weapon for the role). Sunk cost — the bot demon-
+        // strated by having `price` in cash that they could afford this.
+        string? existing = FindOwnedRifle(pawn) ?? FindOwnedSniper(pawn);
+        if (existing != null && existing != preferred)
+        {
+            player.RemoveItemByDesignerName(existing);
+        }
+
+        player.GiveNamedItem(preferred);
+        player.InGameMoneyServices.Account -= price;
+        Utilities.SetStateChanged(player, "CCSPlayerController", "m_pInGameMoneyServices");
+    }
+    // -------------------------------------------------------------------------
+    private static bool HasWeapon(CCSPlayerPawn pawn, string designerName)
+    {
+        var weapons = pawn.WeaponServices?.MyWeapons;
+        if (weapons == null) return false;
+
+        foreach (var handle in weapons)
+        {
+            var w = handle.Value;
+            if (w != null && w.IsValid && w.DesignerName == designerName) return true;
+        }
+        return false;
     }
     // -------------------------------------------------------------------------
     private ProProfile? MatchProfile(string botName)
@@ -625,16 +729,18 @@ public sealed class ProProfile
     public bool NeverWaitsBetweenShots { get; set; } = false;
     public bool NoApproachPause      { get; set; } = false;
 
-    // "I main rifles." Pure preference — we do not buy, give, refund or
-    // touch the bot's account. Every tick, if the bot is currently holding
-    // a non-rifle but already owns one in inventory, `use weapon_*` switches
-    // them back. The engine + BotBuy fully decide what weapon the bot owns;
-    // we only steer the active slot among what they already have.
+    // "I main rifles." Two effects:
+    //   1. At round-freeze: if the bot has the AK / M4 full price (2700/2900)
+    //      in cash AND doesn't already own the preferred rifle, buy it. Any
+    //      other big primary the engine gave them is dropped (sunk cost). No
+    //      refunds, no fake money — strict "buy iff you have the cash".
+    //   2. Per tick: if the bot is holding a non-rifle but already owns one,
+    //      `use weapon_*` switches them back to it.
     public bool Rifler               { get; set; } = false;
 
-    // AWPer mirror of Rifler. Same pure-preference logic: if the bot owns
-    // an AWP / SSG08 in inventory, switch to it. If the engine never gave
-    // them a sniper this round, they play whatever they have.
+    // AWPer mirror of Rifler. Same strict "buy if you have 4750 in cash"
+    // at round-freeze for the AWP; same per-tick switch-back to a sniper if
+    // currently held weapon is something else.
     public bool AWPer                { get; set; } = false;
 
     // Counter-strafe at engagement onset, gated by probability so the bot

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.cs
@@ -88,6 +88,14 @@ public class ProImitator : BasePlugin
         RegisterEventHandler<EventPlayerTeam>(OnPlayerTeam);
         RegisterListener<Listeners.OnTick>(OnTick);
 
+        // Register commands as plain game console commands (mirrors how the
+        // rest of the suite exposes `bot_aim`, `bot_nades`, etc.) so they
+        // don't hit the CSS admin permission check that `css_*` commands do
+        // by default. Public inspection commands; no destructive operations.
+        AddCommand("pro_list",     "List Pro-Imitator profiles loaded from disk",          OnProListCmd);
+        AddCommand("pro_assigned", "List bots that currently have a Pro-Imitator profile", OnProAssignedCmd);
+        AddCommand("pro_reload",   "Re-read JSON profiles from disk",                       OnProReloadCmd);
+
         Console.WriteLine($"[Pro-Imitator] loaded with {_profiles.Count} profile(s): "
                           + string.Join(", ", _profiles.Values.Select(p => p.Name)));
     }
@@ -449,12 +457,11 @@ public class ProImitator : BasePlugin
         return null;
     }
     // -------------------------------------------------------------------------
-    // Console commands. Mirrors the convention used elsewhere in the suite:
-    // `css_*` prefix, [ConsoleCommand] + [CommandHelper] attributes, reply via
-    // CommandInfo so both server console and client console see the output.
+    // Console commands. Exposed via AddCommand (not the `[ConsoleCommand]`
+    // attribute with a `css_*` name) so they behave like the suite's other
+    // user-facing commands (`bot_aim`, `bot_nades`) instead of hitting the CSS
+    // admin permission check. All commands are read-only / informational.
     // -------------------------------------------------------------------------
-    [ConsoleCommand("css_pro_list", "List Pro-Imitator profiles loaded from disk")]
-    [CommandHelper(minArgs: 0, usage: "", whoCanExecute: CommandUsage.CLIENT_AND_SERVER)]
     public void OnProListCmd(CCSPlayerController? caller, CommandInfo cmd)
     {
         if (_profiles.Count == 0)
@@ -471,8 +478,6 @@ public class ProImitator : BasePlugin
         }
     }
     // -------------------------------------------------------------------------
-    [ConsoleCommand("css_pro_assigned", "List bots that currently have a Pro-Imitator profile attached")]
-    [CommandHelper(minArgs: 0, usage: "", whoCanExecute: CommandUsage.CLIENT_AND_SERVER)]
     public void OnProAssignedCmd(CCSPlayerController? caller, CommandInfo cmd)
     {
         if (_assigned.Count == 0)
@@ -498,8 +503,6 @@ public class ProImitator : BasePlugin
         }
     }
     // -------------------------------------------------------------------------
-    [ConsoleCommand("css_pro_reload", "Re-read JSON profiles from disk and re-evaluate all bots")]
-    [CommandHelper(minArgs: 0, usage: "", whoCanExecute: CommandUsage.CLIENT_AND_SERVER)]
     public void OnProReloadCmd(CCSPlayerController? caller, CommandInfo cmd)
     {
         int oldCount = _profiles.Count;

--- a/addons/counterstrikesharp/plugins/ProImitator/ProImitator.csproj
+++ b/addons/counterstrikesharp/plugins/ProImitator/ProImitator.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>ProImitator</AssemblyName>
+    <RootNamespace>ProImitator</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.367" />
+  </ItemGroup>
+
+  <!-- Ship the JSON profiles next to the DLL so the plugin can find them at
+       runtime via Path.Combine(ModuleDirectory, "profiles"). -->
+  <ItemGroup>
+    <None Include="profiles\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/addons/counterstrikesharp/plugins/ProImitator/README.md
+++ b/addons/counterstrikesharp/plugins/ProImitator/README.md
@@ -1,28 +1,38 @@
 # Pro-Imitator
 
-A small CounterStrikeSharp plugin that layers **per-bot personality presets** on
-top of the rest of the CS2-Bot-Improver suite. When a bot is spawned via
-`bot_add_ct "donk"` (or any name listed in a profile's `MatchByName`), this
-plugin reads `profiles/<pro>.json` and writes a handful of `CCSBot` properties
-each tick so the bot starts to *feel* like that player.
+A CounterStrikeSharp plugin that layers **per-bot personality presets** on top
+of the rest of the ed0ard/CS2-Bot-Improver suite. When a bot is spawned via
+`bot_add_ct "ZywOo"` (or any name listed in a profile's `MatchByName`), the
+plugin reads `profiles/<pro>.json` and applies a coherent set of behavioural
+biases each tick so the bot starts to *play* like that pro.
 
-## What it changes — and what it deliberately does **not**
+The goal is not to make bots aim-bot strong — `BotAI` and `BotAimImprover`
+already cover raw mechanical skill. The goal is **identity**: when you
+spectate a round of "Vitality vs Spirit on de_dust2", the bots should
+visibly fragment into recognisable roles — donk rushing site, sh1ro
+holding long, apEX coordinating from second-in, etc. — and play the round
+the way a pro team would.
+
+## What it does — and what it deliberately does **not**
 
 | It does                                                                  | It does **not** |
 |--------------------------------------------------------------------------|-----------------|
-| Pick a profile based on the bot's in-game name at spawn                  | Override the global `bot_aim` style (use `bot_aim head` manually for donk) |
-| Per-tick set timers like `HurryTimer`, `SneakTimer`, `PoliteTimer`       | Patch the CS2 binary (that's `BotAI`'s job) |
-| Reset `SafeTime` / `PanicTimer` for profiled bots                        | Hook native `PickNewAimSpot` (that's `BotAimImprover`'s job) |
-| Persist profile -> slot until team change                                | Drive pathing or waypoint following (no nav-mesh override) |
+| Pick a profile based on the bot's in-game name at spawn                  | Override the global `bot_aim` style (use `bot_aim head` manually) |
+| Apply trait-driven per-tick writes to `CCSBot` schema fields             | Patch the CS2 binary (that's `BotAI`'s job) |
+| Buy the role's preferred weapon if the bot has the cash                  | Refund-then-buy (no fake money — see V4.7 spec below) |
+| Swap to the role weapon when the bot is holding something else           | Hook native `PickNewAimSpot` (that's `BotAimImprover`'s job) |
+| Track pre/post-plant phase and invert attacker/defender roles            | Override the engine's bombsite assignment |
+| Hold the knife between angles when no opponent is in combat range        | Drive pathing or waypoint following (no nav-mesh override) |
+| Detect a dropped bomb and harden CT defence around it                    | Distribute CTs across A / B / mid (engine handles that) |
 
-The whole plugin is **additive** and only writes properties that are either
-left alone by `BotState` or that `BotState` sets to the same value (e.g.
+The plugin is **additive** and only writes properties that are either left
+alone by `BotState` or that `BotState` sets to the same value (e.g.
 `PanicTimer = 0`). It never fights another plugin's intent.
 
 ## Installation
 
-The same way as every other plugin in the suite — once built, drop the output
-folder into `csgo/addons/counterstrikesharp/plugins/`.
+The same way as every other plugin in the suite — once built, drop the
+output folder into `csgo/addons/counterstrikesharp/plugins/`:
 
 ```
 ProImitator/
@@ -30,64 +40,289 @@ ProImitator/
 ├── ProImitator.deps.json
 ├── ProImitator.pdb
 └── profiles/
+    ├── _template.json
     ├── donk.json
-    └── _template.json
+    ├── ZywOo.json
+    └── (… 25 more)
 ```
 
-`_template.json` is skipped at load (filenames starting with `_` are treated as
-examples), so it ships safely.
+Files in `profiles/` whose name starts with `_` are skipped at load
+(treated as examples / templates), so `_template.json` ships safely.
+
+For local development there's a `toggle_cs2_install.ps1` helper that
+copies the freshly-built DLL + profiles into the CS2 install:
+
+```powershell
+.\toggle_cs2_install.ps1 enable   # deploy to CS2
+.\toggle_cs2_install.ps1 disable  # remove from CS2 (other plugins untouched)
+.\toggle_cs2_install.ps1 status   # is it installed?
+```
 
 ## Usage
 
-1. Make sure `BotAimImprover` is loaded and set the global aim style to match
-   the profiled bot's character. For donk:
-   ```
-   bot_aim head
-   ```
-2. Spawn the pro by their exact nick:
-   ```
-   bot_add_ct "donk"
-   ```
-   The plugin logs the attach on the server console:
-   ```
-   [Pro-Imitator] attached profile 'donk' to bot 'donk' (slot 7)
-   ```
-3. Inspect at any time:
-   ```
-   pro_list       # all profiles loaded from disk
-   pro_assigned   # which live bots currently have a profile
-   pro_reload     # re-read profiles after editing JSON
-   ```
-   These are plain game console commands (no `css_` prefix), same UX as
-   `bot_aim` / `bot_nades` — no admin permission needed.
+### Public commands (no admin required)
+
+These are plain game console commands — no `css_` prefix, so they don't
+hit the CSS admin permission check. Same UX as `bot_aim` / `bot_nades`.
+
+| Command | What it does |
+|---|---|
+| `pro_list` | List all profiles loaded from disk, with their roles |
+| `pro_assigned` | List bots that currently have a profile attached |
+| `pro_reload` | Re-read profiles from disk after editing JSON |
+| `pro_debug` | Toggle verbose chat logging for behaviour events |
+
+### Spawning a profiled bot
+
+The bot's in-game name must match an entry in some profile's
+`MatchByName` array. Case-insensitive.
+
+```
+bot_add_ct "ZywOo"
+bot_add_t  "donk"
+```
+
+The plugin logs the attach on the server console:
+
+```
+[Pro-Imitator] attached profile 'ZywOo' to bot 'ZywOo' (slot 2)
+```
+
+For pre-rostered team setups see `Commands.txt` at the repo root.
+
+### Quick match — Vitality (CT) vs Spirit (T) on Dust2
+
+```
+map de_dust2
+```
+
+(wait for the map to load)
+
+```
+sv_cheats 1; mp_warmuptime 0; mp_warmup_end; mp_maxrounds 24; mp_overtime_enable 1;
+mp_match_can_clinch 1; bot_difficulty 3; mp_friendlyfire 0; mp_autoteambalance 0;
+mp_limitteams 0; bot_kick; pro_reload;
+bot_add_ct "apEX"; bot_add_ct "ZywOo"; bot_add_ct "ropz"; bot_add_ct "mezii"; bot_add_ct "flameZ";
+mp_teamlogo_1 vita; mp_teamname_1 Team Vitality;
+bot_add_t "donk"; bot_add_t "zont1x"; bot_add_t "magixx"; bot_add_t "tN1R"; bot_add_t "sh1ro";
+mp_teamlogo_2 spir; mp_teamname_2 Spirit;
+mp_restartgame 3; pro_assigned; jointeam 1
+```
+
+## Profiles
+
+26 profiles ship with the plugin, covering the 2026 rosters of five
+top-tier teams.
+
+### Team Vitality (FR/EU)
+| Bot | Role | Trait highlights |
+|---|---|---|
+| apEX | IGL, Support | Calm captain, Rifler, BombFocus |
+| ZywOo | AWPer | Patient hold, AWPer |
+| ropz | Lurker | Sneaks, Rifler, no BombFocus (flanks on his own) |
+| mezii | Support | Anchor, Rifler, BombFocus |
+| flameZ | Entry Fragger | AlwaysRushing, Rifler, BombFocus |
+
+### FURIA Esports (BR)
+| Bot | Role | Trait highlights |
+|---|---|---|
+| FalleN | IGL, Support | Veteran caller, Rifler, BombFocus |
+| yuurih | Lurker, Entry Fragger | Sneaks, Rifler |
+| KSCERATO | Entry Fragger, Support | AlwaysRushing, Rifler, BombFocus |
+| YEKINDAR | Entry Fragger | Aggressive entry, BombFocus |
+| molodoy | AWPer | Patient hold, AWPer |
+
+### Team Falcons (SA)
+| Bot | Role | Trait highlights |
+|---|---|---|
+| karrigan | IGL, Support | Strategic veteran, Rifler, BombFocus |
+| NiKo | Entry Fragger, Lurker | Star rifler, Rifler, BombFocus |
+| m0NESY | AWPer | Aggressive AWP variant |
+| TeSeS | Support | Anchor, Rifler, BombFocus |
+| kyousuke | Entry Fragger | Young aim freak, Rifler, BombFocus |
+
+### Natus Vincere (UA/EU)
+| Bot | Role | Trait highlights |
+|---|---|---|
+| Aleksib | IGL, Support | Tactical caller, Rifler, BombFocus |
+| iM | Entry Fragger | Dynamic, Rifler, BombFocus |
+| b1t | Lurker, Support | Sneaks, Rifler |
+| w0nderful | AWPer | Patient hold, AWPer |
+| makazze | Entry Fragger | Hyper-aggressive, Rifler, BombFocus |
+
+### Team Spirit (CIS)
+| Bot | Role | Trait highlights |
+|---|---|---|
+| magixx | IGL, Support | New captain, Rifler, BombFocus |
+| sh1ro | AWPer | World-class closer, AWPer |
+| tN1R | Lurker, Support | CT anchor / T lurker, Rifler |
+| zont1x | Entry Fragger | Space-taker, Rifler, BombFocus |
+| donk | Entry Fragger | Star entry, Rifler, BombFocus |
+
+Role taxonomy follows the [dmarket CS2 roles guide](https://dmarket.com/blog/cs2-roles-guide/)
+(Entry Fragger / Support / Lurker / AWPer / IGL). Multi-role bots use a
+comma-separated string in their `Role` field; the primary role drives the
+behavioural flag template.
+
+## Architecture
+
+The plugin is a single-file C# implementation (`ProImitator.cs`). Behaviour
+is organised into five "versions" of features that build on each other:
+
+### V1 — Foundation
+Profile loading from JSON, per-bot slot tracking, basic trait flags:
+`AlwaysRushing`, `NeverSneaks`, `NeverPolite`, `NoSafeTime`, `NoPanic`.
+Each flag maps to one or two `CCSBot` schema writes per tick.
+
+### V2 — Visual identity
+Behavioural quirks that make the bot read as a specific player:
+`NoCrouchWithRifle` (stand-spray identity), `NeverWaitsBetweenShots`,
+`NoApproachPause`, and a probabilistic `CounterStrafeChance` that
+zeroes lateral velocity on the false→true edge of `IsAimingAtEnemy`
+so the bot's first shot lands like a real counter-strafe.
+
+### V3 — Role weapons
+`Rifler` and `AWPer` flags express the bot's main weapon. Per-tick logic
+forces `use weapon_<name>` when the bot is holding the wrong slot. At
+round-freeze a strict buy logic runs:
+
+- If the bot has the role weapon's full price in cash AND doesn't already
+  own any same-class weapon (rifle for Rifler, sniper for AWPer), buy it.
+- No refund credits, no swap math — strict price-in-cash gate. This is
+  the V3 spec the user asked for: *"juste la manière dont BotBuy fonctionne
+  avec des préférences par rôle, pas de manip de thune"*.
+- **V4.7 update**: if the bot already owns ANY rifle (e.g. a CT mezii
+  carrying over an AK picked up off a dead T), the role buy is skipped.
+  AK is universally preferred and a CT willingly keeps a picked-up AK
+  over their default M4.
+
+### V4 — Objective awareness (BombFocus)
+The `BombFocus` flag biases the bot toward the round's win condition
+instead of mid-round fragfest behaviour. Implementation went through
+several calibration passes (V4.1 → V4.8) based on playtest feedback;
+see the in-code banner comment in `ApplyPersonality` for the full
+design discussion.
+
+Current behaviour (V4.8):
+
+| Phase | Side | Effect |
+|---|---|---|
+| Pre-plant | T attacker | `HurryTimer` 10s biased toward objective |
+| Pre-plant | T attacker (bomb carrier) | `HurryTimer` 30s + 50/50 `IsRunning` coinflip on 3s windows |
+| Pre-plant | CT defender | `SafeTime` 6s + `HurryTimer` explicitly cleared |
+| Pre-plant | CT defender (within 1500u of a dropped bomb) | `SafeTime` 9s — hold the bomb perimeter harder |
+| Post-plant | T defender | `SafeTime` 6s + `HurryTimer` cleared — hold the plant |
+| Post-plant | CT attacker | `HurryTimer` 10s — push to retake / defuse |
+
+Pre/post-plant flip is driven by `EventBombPlanted` setting a `_bombPlanted`
+flag, reset on `EventRoundStart`. The dropped-bomb position is found each
+tick by walking weapon_c4 entities for an unowned one.
+
+The bomb-carrier extra push is a **slight** bias (HurryTimer 30s vs 10s
+for other Ts) plus a 50/50 coinflip on whether to force `IsRunning=true`
+for the next 3-second window. Earlier iterations (V4.1) forced
+`IsRunning=true` permanently and wiped `SneakTimer / PoliteTimer /
+IsWaitingBehindFriend` — that produced a hold-W zombie carrier that
+*"se jetait sur le site"*. V4.4 dialled it back to subtle.
+
+### V4.5 — KnifeRush + Observability + Dropped-bomb defence
+- `KnifeRush` flag: hold the knife (≈20% movement bonus) whenever no
+  alive opponent is within 1500u of the bot. As soon as an opponent
+  enters that radius, the Rifler / AWPer per-tick switch pulls the
+  primary. **V4.8 dropped the time window — the trait is now pure
+  distance-gated**, no `KnifeRushSec` time parameter, behaviour applies
+  any time during the round.
+- `pro_debug` command: routes lifecycle / state-change events to the
+  in-game chat as `[ProDBG]` lines. Server console gets the same lines
+  via `Console.WriteLine`. Useful to verify that a feature is actually
+  firing (e.g. *"the knife isn't appearing, is my code even running?"*).
+- Dropped-bomb defence: CTs with BombFocus and within 1500u of a
+  dropped (unowned) C4 entity get an extra-firm hold (SafeTime 9s).
+  Denies T pickup attempts.
+
+### V4.7 — Schema-level active weapon write
+Earlier versions issued `slot3` (and briefly `use weapon_knife` via
+`Server.ExecuteCommand`, which doesn't exist as a CS2 cvar) for the
+knife switch. Playtests showed both commands lose the race against the
+engine's bot-AI weapon selection, which runs every server tick.
+
+V4.7 added a direct schema write to `CPlayer_WeaponServices.m_hActiveWeapon`
+that bypasses the command queue entirely. The `slot3` command is kept
+as a belt-and-braces fallback in case the schema field is ever renamed.
+Wrapped in try/catch so a future CSS API change can't crash the server
+tick on this polish feature.
+
+## Trait reference
+
+| Flag | Effect (per tick) |
+|---|---|
+| `AlwaysRushing` | `HurryTimer.Duration` and `Timestamp` maxed; `IsRunning` true |
+| `NeverSneaks` | `SneakTimer` zeroed |
+| `NeverPolite` | `PoliteTimer` zeroed; `IsWaitingBehindFriend` false |
+| `NoSafeTime` | `SafeTime` zeroed |
+| `NoPanic` | `PanicTimer` zeroed |
+| `NoCrouchWithRifle` | `IsCrouching` forced false when active weapon is a rifle |
+| `NeverWaitsBetweenShots` | `FireWeaponTimestamp` zeroed; `IsRapidFiring` true |
+| `NoApproachPause` | `InhibitLookAroundTimestamp` zeroed; `CheckedHidingSpotCount` zeroed |
+| `Rifler` | Per-tick switch to AK / M4 (AK preferred when owned); role-buy at freeze |
+| `AWPer` | Per-tick switch to AWP / SSG08; role-buy at freeze |
+| `CounterStrafeChance` | Probability-gated lateral-velocity stop on engagement onset |
+| `KnifeRush` | Hold knife when no opponent within 1500u (V4.8 distance-only) |
+| `BombFocus` | Objective bias: HurryTimer for attackers, SafeTime for defenders, pre/post-plant inverts |
+
+All flags default to `false`. Profiles opt in to whatever fits the
+role. See `profiles/_template.json` for the documented field-by-field
+reference and `profiles/donk.json` for a worked example.
 
 ## Adding a new pro
 
-Copy `profiles/_template.json` to e.g. `profiles/zywoo.json`, set `Name` and
-`MatchByName`, then toggle the behavior flags. Run `pro_reload` to pick up
-the change without restarting the server.
+1. Copy `profiles/_template.json` to e.g. `profiles/s1mple.json`.
+2. Set `Name`, `MatchByName`, `Role`, `Description`.
+3. Set behavioural flags to match the role template — the comments in
+   `_template.json` document the per-role canonical trait set.
+4. Run `pro_reload` to pick up the change without restarting CS2.
 
-If you need a trait that isn't represented by an existing flag, the recipe is:
+If you need a trait that isn't represented by an existing flag, the
+recipe is:
 
 1. Add a `bool` property to `ProProfile` in `ProImitator.cs` (default `false`).
-2. Add an `if (prof.NewTrait) { ... }` block to `ApplyPersonality` that writes
-   the `ref` field(s) on `CCSBot`.
+2. Add an `if (prof.NewTrait) { … }` block to `ApplyPersonality` that writes
+   the relevant `ref` field(s) on `CCSBot`.
+3. Document it in `_template.json` so contributors see it.
 
-That's it — no event hooks or service plumbing for a new personality dimension,
-just a tiny per-tick write.
+That's it — no event hooks or service plumbing for a new personality
+dimension, just a tiny per-tick write.
 
-## V1 scope vs. what's intentionally left for later
+## What's intentionally out of scope
 
-V1 is deliberately small. Things on the wish-list:
+The plugin deliberately doesn't try to:
 
-- **Per-bot `bot_aim` style override**: would need to add a hook in
-  `BotAimImprover` so a sibling plugin can opt a single bot into a different
-  priority chain (head/jaw/body) without flipping the global mode.
-- **Reaction-time scaling**: writing `AlertTimer` / `IgnoreEnemiesTimer` with
-  profile-specific timescale.
-- **Weapon affinity**: integrating with `BotBuy` so a profiled bot leans
-  toward a specific buy when the user runs the coordinated-buy commands.
+- **Override the engine's bombsite assignment** — CS2's nav system
+  already assigns CT bots to A / B / mid at scenario init. Forcing a
+  specific 2/2/1 split would fight that. Documented as future work
+  in the V4 banner.
+- **Map-specific path overrides** — no Dust2-specific `mid_doors`
+  knowledge baked into the plugin. The 1500u distance threshold for
+  KnifeRush / dropped-bomb defence is a tunable but it's the only
+  spatial constant.
+- **Memory patches** — those live in `BotAI`. ProImitator only writes
+  schema fields and issues commands.
+- **Aim style override per bot** — that would need a hook into
+  `BotAimImprover` so a sibling plugin can opt a single bot into a
+  different priority chain (head/jaw/body) without flipping the global
+  mode. Suggested upstream change, not in this plugin.
+- **Reaction-time scaling** — `AlertTimer` / `IgnoreEnemiesTimer`
+  per-profile would be a clean extension if needed.
 
-These all live in the same architectural niche (additive, profile-driven, no
-fights with other plugins) — they just weren't needed to validate the V1
-concept.
+## Credits
+
+By **Ouistiti**.
+
+Layered on top of the [ed0ard/CS2-Bot-Improver](https://github.com/ed0ard/CS2-Bot-Improver)
+suite — none of this would exist without the BotAI / BotState / BotBuy /
+BotAimImprover plumbing that handles the heavy lifting.
+
+Role taxonomy from the [dmarket CS2 roles guide](https://dmarket.com/blog/cs2-roles-guide/).
+
+Roster information cross-referenced from HLTV team pages and Liquipedia,
+2026 active rosters as of the time of writing.

--- a/addons/counterstrikesharp/plugins/ProImitator/README.md
+++ b/addons/counterstrikesharp/plugins/ProImitator/README.md
@@ -1,0 +1,91 @@
+# Pro-Imitator
+
+A small CounterStrikeSharp plugin that layers **per-bot personality presets** on
+top of the rest of the CS2-Bot-Improver suite. When a bot is spawned via
+`bot_add_ct "donk"` (or any name listed in a profile's `MatchByName`), this
+plugin reads `profiles/<pro>.json` and writes a handful of `CCSBot` properties
+each tick so the bot starts to *feel* like that player.
+
+## What it changes — and what it deliberately does **not**
+
+| It does                                                                  | It does **not** |
+|--------------------------------------------------------------------------|-----------------|
+| Pick a profile based on the bot's in-game name at spawn                  | Override the global `bot_aim` style (use `bot_aim head` manually for donk) |
+| Per-tick set timers like `HurryTimer`, `SneakTimer`, `PoliteTimer`       | Patch the CS2 binary (that's `BotAI`'s job) |
+| Reset `SafeTime` / `PanicTimer` for profiled bots                        | Hook native `PickNewAimSpot` (that's `BotAimImprover`'s job) |
+| Persist profile -> slot until team change                                | Drive pathing or waypoint following (no nav-mesh override) |
+
+The whole plugin is **additive** and only writes properties that are either
+left alone by `BotState` or that `BotState` sets to the same value (e.g.
+`PanicTimer = 0`). It never fights another plugin's intent.
+
+## Installation
+
+The same way as every other plugin in the suite — once built, drop the output
+folder into `csgo/addons/counterstrikesharp/plugins/`.
+
+```
+ProImitator/
+├── ProImitator.dll
+├── ProImitator.deps.json
+├── ProImitator.pdb
+└── profiles/
+    ├── donk.json
+    └── _template.json
+```
+
+`_template.json` is skipped at load (filenames starting with `_` are treated as
+examples), so it ships safely.
+
+## Usage
+
+1. Make sure `BotAimImprover` is loaded and set the global aim style to match
+   the profiled bot's character. For donk:
+   ```
+   bot_aim head
+   ```
+2. Spawn the pro by their exact nick:
+   ```
+   bot_add_ct "donk"
+   ```
+   The plugin logs the attach on the server console:
+   ```
+   [Pro-Imitator] attached profile 'donk' to bot 'donk' (slot 7)
+   ```
+3. Inspect at any time:
+   ```
+   css_pro_list       # all profiles loaded from disk
+   css_pro_assigned   # which live bots currently have a profile
+   css_pro_reload     # re-read profiles after editing JSON
+   ```
+
+## Adding a new pro
+
+Copy `profiles/_template.json` to e.g. `profiles/zywoo.json`, set `Name` and
+`MatchByName`, then toggle the behavior flags. Run `css_pro_reload` to pick up
+the change without restarting the server.
+
+If you need a trait that isn't represented by an existing flag, the recipe is:
+
+1. Add a `bool` property to `ProProfile` in `ProImitator.cs` (default `false`).
+2. Add an `if (prof.NewTrait) { ... }` block to `ApplyPersonality` that writes
+   the `ref` field(s) on `CCSBot`.
+
+That's it — no event hooks or service plumbing for a new personality dimension,
+just a tiny per-tick write.
+
+## V1 scope vs. what's intentionally left for later
+
+V1 is deliberately small. Things on the wish-list:
+
+- **Per-bot `bot_aim` style override**: would need to add a hook in
+  `BotAimImprover` so a sibling plugin can opt a single bot into a different
+  priority chain (head/jaw/body) without flipping the global mode.
+- **Reaction-time scaling**: writing `AlertTimer` / `IgnoreEnemiesTimer` with
+  profile-specific timescale.
+- **Weapon affinity**: integrating with `BotBuy` so a profiled bot leans
+  toward a specific buy when the user runs the coordinated-buy commands.
+
+These all live in the same architectural niche (additive, profile-driven, no
+fights with other plugins) — they just weren't needed to validate the V1
+concept.

--- a/addons/counterstrikesharp/plugins/ProImitator/README.md
+++ b/addons/counterstrikesharp/plugins/ProImitator/README.md
@@ -54,15 +54,17 @@ examples), so it ships safely.
    ```
 3. Inspect at any time:
    ```
-   css_pro_list       # all profiles loaded from disk
-   css_pro_assigned   # which live bots currently have a profile
-   css_pro_reload     # re-read profiles after editing JSON
+   pro_list       # all profiles loaded from disk
+   pro_assigned   # which live bots currently have a profile
+   pro_reload     # re-read profiles after editing JSON
    ```
+   These are plain game console commands (no `css_` prefix), same UX as
+   `bot_aim` / `bot_nades` — no admin permission needed.
 
 ## Adding a new pro
 
 Copy `profiles/_template.json` to e.g. `profiles/zywoo.json`, set `Name` and
-`MatchByName`, then toggle the behavior flags. Run `css_pro_reload` to pick up
+`MatchByName`, then toggle the behavior flags. Run `pro_reload` to pick up
 the change without restarting the server.
 
 If you need a trait that isn't represented by an existing flag, the recipe is:

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -82,8 +82,9 @@
   // "This pro is a rifler." Two effects:
   //
   //   1. AT ROUND-FREEZE: if the bot has the FULL rifle price in cash
-  //      (AK 2700 for T, M4A1 2900 for CT) AND doesn't already own the
-  //      preferred rifle, ProImitator buys it. Strict rule — no refund
+  //      (2700, same for AK and M4A1 in current CS2) AND doesn't already
+  //      own the preferred rifle, ProImitator buys it. Strict rule — no
+  //      refund
   //      credits, no swap math, no fake money. The price in cash IS the
   //      "full-buy phase" detector: under it, ProImitator does nothing
   //      (BotBuy and the engine handle eco / semi-buy / save).

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -43,5 +43,31 @@
   // Force PanicTimer = 0 every tick. BotState already does this too, but
   // setting it here means the personality is self-contained if BotState ever
   // gets unloaded.
-  "NoPanic": false
+  "NoPanic": false,
+
+  // ---- V2 visual-identity traits --------------------------------------------
+  // These are the markers that make a profiled bot READ as the specific player
+  // to a spectator, rather than just "yet another aggressive bot".
+  // ---------------------------------------------------------------------------
+
+  // Force IsCrouching=false EVERY TICK whenever the bot is holding a rifle
+  // (AK47, M4A1/M4A1-S, SG556, AUG, GalilAR, FAMAS). The classifier is in
+  // RifleDesignerNames in ProImitator.cs — pistols / SMGs / snipers / shotguns
+  // are left alone so e.g. a Deagle-pop scenario still looks natural.
+  //
+  // This is the SINGLE biggest visual marker for stand-spray riflers like donk:
+  // BotState's per-shot crouch chance is 50% for rifles. Setting this trait
+  // overrides that to 0% and produces the recognisable upright-spray silhouette.
+  "NoCrouchWithRifle": false,
+
+  // Zero FireWeaponTimestamp + IsRapidFiring=true each tick. The bot never
+  // throttles its rate of fire between bursts. Pair with NoCrouchWithRifle
+  // for the "click-click-click-click" donk feel.
+  "NeverWaitsBetweenShots": false,
+
+  // Skip "pause and check angles" beats at ApproachPoints during traversal.
+  // Hyper-aggressive players are already committed before reaching the angle
+  // and engage the moment they see an enemy. Sets InhibitLookAroundTimestamp
+  // and CheckedHidingSpotCount to zero.
+  "NoApproachPause": false
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -81,10 +81,10 @@
 
   // "This pro is a rifler." Two coordinated effects, both eco-aware:
   //
-  //   1. AT ROUND-FREEZE: if the bot can afford a full buy (rifle + armor =
-  //      3700$ for T with AK, 3900$ for CT with M4) AND doesn't already own
-  //      a rifle, ProImitator buys their team's main rifle (AK for T, M4
-  //      for CT) and deducts the price from their account.
+  //   1. AT ROUND-FREEZE: if the bot can afford a full buy (5000$ floor =
+  //      rifle + armor + minimal nade kit) AND doesn't already own a rifle,
+  //      ProImitator buys their team's main rifle (AK for T, M4 for CT)
+  //      and deducts the price from their account.
   //
   //      Below the full-buy floor → DO NOTHING. The bot falls back to
   //      whatever BotBuy / the engine bought (pistol round, eco SMG, etc).
@@ -99,10 +99,10 @@
   "Rifler": false,
 
   // AWPer mirror of Rifler. Same eco logic with the AWP full-buy floor at
-  // 5750$ (AWP 4750 + 1000 armor). Same per-tick switch-back if the bot picks
-  // up a teammate's dropped rifle. SSG08 is also classified as a sniper, so
-  // a profiled AWPer with Scout from an early-round eco buy won't be force-
-  // switched out of it.
+  // 6500$ (AWP 4750 + armor 1000 + nades + pistol upgrade). Same per-tick
+  // switch-back if the bot picks up a teammate's dropped rifle. SSG08 is also
+  // classified as a sniper, so a profiled AWPer with Scout from an early-
+  // round eco buy won't be force-switched out of it.
   "AWPer": false,
 
   // Counter-strafe at engagement onset, gated by probability. On the

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -79,16 +79,22 @@
   // and CheckedHidingSpotCount to zero.
   "NoApproachPause": false,
 
-  // "This pro is a rifler." Pure preference — ProImitator does NOT buy,
-  // give, refund or touch the bot's account. The engine + BotBuy fully
-  // own the economic decisions (eco / semi-buy / full-buy, what weapon to
-  // give, when to refund). All this trait does:
+  // "This pro is a rifler." Two effects:
   //
-  //   - Every tick, if the bot is holding a non-rifle (pistol, knife from
-  //     reload-switch, etc) but already owns a rifle in inventory, issue
-  //     `use weapon_<rifle>` to switch the active slot back. If the engine
-  //     never gave the bot a rifle this round, nothing happens — the bot
-  //     plays whatever they have.
+  //   1. AT ROUND-FREEZE: if the bot has the FULL rifle price in cash
+  //      (AK 2700 for T, M4A1 2900 for CT) AND doesn't already own the
+  //      preferred rifle, ProImitator buys it. Strict rule — no refund
+  //      credits, no swap math, no fake money. The price in cash IS the
+  //      "full-buy phase" detector: under it, ProImitator does nothing
+  //      (BotBuy and the engine handle eco / semi-buy / save).
+  //
+  //      Any other big primary the engine gave the bot (Galil, AUG,
+  //      Scout, etc) is dropped without refund — the bot demonstrated
+  //      by having `price` cash on top that they could afford this.
+  //
+  //   2. EVERY TICK: if the bot is holding a non-rifle (pistol from auto-
+  //      switch on empty mag, knife, etc) AND owns a rifle, issue
+  //      `use weapon_<rifle>` to switch the active slot back.
   //
   // Rifles classified: AK47, M4A1 / M4A1-S, SG556, AUG, GalilAR, FAMAS.
   //
@@ -96,11 +102,9 @@
   // makes sense per bot.
   "Rifler": false,
 
-  // AWPer mirror of Rifler. Pure preference: if the engine ever gave the
-  // bot an AWP / SSG08 and they're currently holding something else,
-  // switch back. Otherwise, no-op. We never conjure an AWP for them — if
-  // BotBuy and the engine decide the bot can't afford or shouldn't AWP
-  // this round, we respect that.
+  // AWPer mirror of Rifler. Same strict "buy iff has 4750 cash" rule for
+  // the AWP at round-freeze; same per-tick switch-back to a sniper if
+  // currently held weapon is something else.
   "AWPer": false,
 
   // Counter-strafe at engagement onset, gated by probability. On the

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -79,38 +79,37 @@
   // and CheckedHidingSpotCount to zero.
   "NoApproachPause": false,
 
-  // "This pro is a rifler." Two coordinated effects, both deferring the
-  // eco / semi-buy / full-buy decision to the engine + BotBuy:
+  // "This pro is a rifler." All-or-save rule, observed at round-freeze:
   //
-  //   1. AT ROUND-FREEZE: ProImitator observes what the bot was given by the
-  //      engine and BotBuy. Three cases:
+  //   - Bot has only pistol / SMG / shotgun / nothing → engine called it an
+  //     eco or semi-buy round, ProImitator leaves it alone.
   //
-  //        - Bot has a rifle (any): swap it for the role's main (AK for T,
-  //          M4 for CT). Account adjusted by the PRICE DIFFERENCE — e.g.
-  //          Galil 1800$ → AK 2700$ costs the bot 900$; AUG 3300$ → M4
-  //          2900$ refunds 400$. If the bot can't afford an upgrade, we
-  //          keep the original rifle rather than leave them broke.
+  //   - Bot has a big primary (rifle or sniper) AND can afford the swap to
+  //     the role rifle (AK for T, M4 for CT) → swap. Account is adjusted by
+  //     the PRICE DIFFERENCE: AUG 3300 → M4 2900 refunds 400; Galil 1800 →
+  //     AK 2700 costs 900; AK 2700 → AK 2700 cross-team isn't a thing but
+  //     same-rifle ownership skips the swap entirely (already optimal).
   //
-  //        - Bot has a sniper (AWP / SSG08 / Scar20 / G3SG1): same swap,
-  //          treated as a "wrong primary" → switch to the role rifle.
+  //   - Bot has a big primary but CAN'T afford the swap → REFUND the wrong
+  //     primary and save the money. Without this branch, a Rifler stuck with
+  //     a Krieg (3000) when AK (2700) refund-swap costs nothing wouldn't
+  //     matter, but a Rifler stuck with a Scout (1700) from a force-buy
+  //     round would bleed money round after round. The refund breaks that
+  //     funnel.
   //
-  //        - Bot has only SMG / shotgun / pistol / nothing: LEAVE IT. The
-  //          engine decided it's eco or semi-buy this round; we respect
-  //          that and don't force a rifle the team economy can't sustain.
-  //
-  //   2. EVERY TICK: if the bot is holding a non-rifle (pistol, SMG, etc)
-  //      AND already owns a rifle, `use weapon_<rifle>` switches them back.
-  //      Rifles classified: AK47, M4A1 / M4A1-S, SG556, AUG, GalilAR, FAMAS.
+  // Also, EVERY TICK: if the bot is holding a non-rifle (pistol, SMG, etc)
+  // AND already owns a rifle, `use weapon_<rifle>` switches them back.
+  // Rifles classified: AK47, M4A1 / M4A1-S, SG556, AUG, GalilAR, FAMAS.
   //
   // Don't combine with AWPer in the same profile — they'd both try to swap
-  // primaries at the same tick, and Rifler wins (deterministic but arbitrary).
+  // primaries on the same tick, and Rifler wins (deterministic but arbitrary).
   "Rifler": false,
 
-  // AWPer mirror of Rifler. Same observe-then-swap logic: if the bot was
-  // given any big primary (rifle or sniper), swap to AWP and pay the diff;
-  // if they only got a small primary or nothing, respect the engine's
-  // semi-buy / eco call. SSG08 is classified as a sniper, so an SSG08 pistol-
-  // round pickup will be respected and won't trigger the swap loop.
+  // AWPer mirror of Rifler. Same all-or-save rule with the AWP as the role
+  // weapon: bot has a big primary AND can afford the AWP swap → swap; bot
+  // has a big primary but CAN'T afford the AWP → refund and save (this is
+  // the fix for the Scout / AUG hoarding funnel); bot has only small
+  // primaries / nothing → leave alone.
   "AWPer": false,
 
   // Counter-strafe at engagement onset, gated by probability. On the

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -86,18 +86,25 @@
   // his rifle even after picking up a Deagle from a corpse.
   "RifleOnly": false,
 
-  // Counter-strafe at engagement onset. On the false->true edge of
-  // IsAimingAtEnemy, zero the bot's lateral velocity for ~120ms so the
-  // first tap-shot lands with full standing-still accuracy.
+  // Counter-strafe at engagement onset, gated by probability. On the
+  // false->true edge of IsAimingAtEnemy we roll a die against this chance;
+  // on a success we zero lateral velocity for ~120ms so the first tap-shot
+  // lands with full standing-still accuracy.
   //
-  // Real human pros do this by tapping the opposite-direction movement key
-  // for 1-3 frames to cancel momentum (left-strafe + brief D-tap = stopped).
-  // We achieve the same observable effect by writing AbsVelocity.X/Y = 0 each
-  // tick during the window. Once the window expires, normal movement resumes,
-  // so a sustained spray fight still has the bot strafing — only the first
-  // shot of an engagement gets the freeze.
+  // Real human pros counter-strafe by tapping the opposite-direction
+  // movement key for 1-3 frames to cancel momentum (left-strafe + brief
+  // D-tap = stopped). We achieve the same observable effect by writing
+  // AbsVelocity.X/Y = 0 each tick during the window. Once the window
+  // expires, normal movement resumes — sustained spray fights still have
+  // the bot strafing — only the FIRST shot of an engagement gets the
+  // freeze.
   //
-  // Without this trait the bot run-and-guns and ALWAYS sprays which is
-  // visually wrong for pros who counter-strafe their first taps.
-  "CounterStrafes": false
+  // Values:
+  //   0.0  = never counter-strafe (run-and-gun all engagements)
+  //   1.0  = always counter-strafe (perfect, reads as aimbot)
+  //   0.7-0.8 = pro-level: clean most of the time, occasionally misses
+  //             the timing like a real human would
+  //
+  // Default 0 means the trait is off; pick a value in (0, 1] to enable.
+  "CounterStrafeChance": 0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -14,6 +14,14 @@
   //   "MatchByName": ["s1mple", "S1MPLE", "s1mple_bot"]
   "MatchByName": ["ExamplePro"],
 
+  // Display-only role tag, shown in `pro_list`. Purely documentation: does
+  // NOT change behavior. The point is to make a 5-bot roster legible at a
+  // glance ("oh, this team has 2 entries, 1 AWPer, 1 lurker, 1 IGL") and to
+  // remind profile authors to pick a coherent set of traits for the role
+  // they're modelling. Suggested values: "Entry rifler", "Star rifler",
+  // "Lurker", "AWPer", "AWPer (aggressive)", "IGL", "Support".
+  "Role": "Entry rifler",
+
   // Free-form notes for future maintainers. Not displayed at runtime.
   "Description": "Notes on this player's playstyle and why we chose these traits.",
 
@@ -85,6 +93,17 @@
   // so BotBuy gives every Terrorist / CT an AK / M4. donk will then stick to
   // his rifle even after picking up a Deagle from a corpse.
   "RifleOnly": false,
+
+  // AWPer mirror of RifleOnly. Force-switch back to AWP / SSG08 every time
+  // the bot is holding something else AND owns a sniper. Same no-give
+  // policy: requires the bot to already own the sniper (via the buyscript
+  // or a pickup). Set this true for AWPer profiles so they don't permanently
+  // settle on a teammate's dropped rifle.
+  //
+  // Don't combine with RifleOnly — the two would fight each other every
+  // tick and both wins would cancel out (cooldown protects from spam, but
+  // the bot would never settle).
+  "AwpOnly": false,
 
   // Counter-strafe at engagement onset, gated by probability. On the
   // false->true edge of IsAimingAtEnemy we roll a die against this chance;

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -79,30 +79,38 @@
   // and CheckedHidingSpotCount to zero.
   "NoApproachPause": false,
 
-  // "This pro is a rifler." Two coordinated effects, both eco-aware:
+  // "This pro is a rifler." Two coordinated effects, both deferring the
+  // eco / semi-buy / full-buy decision to the engine + BotBuy:
   //
-  //   1. AT ROUND-FREEZE: if the bot can afford a full buy (5000$ floor =
-  //      rifle + armor + minimal nade kit) AND doesn't already own a rifle,
-  //      ProImitator buys their team's main rifle (AK for T, M4 for CT)
-  //      and deducts the price from their account.
+  //   1. AT ROUND-FREEZE: ProImitator observes what the bot was given by the
+  //      engine and BotBuy. Three cases:
   //
-  //      Below the full-buy floor → DO NOTHING. The bot falls back to
-  //      whatever BotBuy / the engine bought (pistol round, eco SMG, etc).
-  //      No "stupid" rifle buys on a 2200$ account.
+  //        - Bot has a rifle (any): swap it for the role's main (AK for T,
+  //          M4 for CT). Account adjusted by the PRICE DIFFERENCE — e.g.
+  //          Galil 1800$ → AK 2700$ costs the bot 900$; AUG 3300$ → M4
+  //          2900$ refunds 400$. If the bot can't afford an upgrade, we
+  //          keep the original rifle rather than leave them broke.
   //
-  //   2. EVERY TICK: if the bot is holding a non-rifle (pistol, SMG, sniper,
-  //      shotgun) AND owns a rifle, `use weapon_<rifle>` switches them back.
+  //        - Bot has a sniper (AWP / SSG08 / Scar20 / G3SG1): same swap,
+  //          treated as a "wrong primary" → switch to the role rifle.
+  //
+  //        - Bot has only SMG / shotgun / pistol / nothing: LEAVE IT. The
+  //          engine decided it's eco or semi-buy this round; we respect
+  //          that and don't force a rifle the team economy can't sustain.
+  //
+  //   2. EVERY TICK: if the bot is holding a non-rifle (pistol, SMG, etc)
+  //      AND already owns a rifle, `use weapon_<rifle>` switches them back.
   //      Rifles classified: AK47, M4A1 / M4A1-S, SG556, AUG, GalilAR, FAMAS.
   //
-  // Don't combine with AWPer in the same profile — they'd both try to buy a
-  // primary at the same tick, and Rifler wins (deterministic but arbitrary).
+  // Don't combine with AWPer in the same profile — they'd both try to swap
+  // primaries at the same tick, and Rifler wins (deterministic but arbitrary).
   "Rifler": false,
 
-  // AWPer mirror of Rifler. Same eco logic with the AWP full-buy floor at
-  // 6500$ (AWP 4750 + armor 1000 + nades + pistol upgrade). Same per-tick
-  // switch-back if the bot picks up a teammate's dropped rifle. SSG08 is also
-  // classified as a sniper, so a profiled AWPer with Scout from an early-
-  // round eco buy won't be force-switched out of it.
+  // AWPer mirror of Rifler. Same observe-then-swap logic: if the bot was
+  // given any big primary (rifle or sniper), swap to AWP and pay the diff;
+  // if they only got a small primary or nothing, respect the engine's
+  // semi-buy / eco call. SSG08 is classified as a sniper, so an SSG08 pistol-
+  // round pickup will be respected and won't trigger the swap loop.
   "AWPer": false,
 
   // Counter-strafe at engagement onset, gated by probability. On the

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -82,9 +82,8 @@
   // "This pro is a rifler." Two effects:
   //
   //   1. AT ROUND-FREEZE: if the bot has the FULL rifle price in cash
-  //      (2700, same for AK and M4A1 in current CS2) AND doesn't already
-  //      own the preferred rifle, ProImitator buys it. Strict rule — no
-  //      refund
+  //      (AK 2700 for T, M4A4 2900 for CT) AND doesn't already own the
+  //      preferred rifle, ProImitator buys it. Strict rule — no refund
   //      credits, no swap math, no fake money. The price in cash IS the
   //      "full-buy phase" detector: under it, ProImitator does nothing
   //      (BotBuy and the engine handle eco / semi-buy / save).

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -1,0 +1,47 @@
+{
+  // Files whose name starts with '_' are skipped by Pro-Imitator at load time,
+  // so this template ships safely next to real profiles. Copy it to e.g.
+  // `s1mple.json` (or whichever pro you're modelling) and edit.
+
+  // Display name shown in `css_pro_list` and server logs.
+  "Name": "ExamplePro",
+
+  // List of bot in-game names that should receive this profile when they
+  // spawn. Matched case-insensitively against `bot.PlayerName`. Typically the
+  // pro's nick exactly as it appears in `bot_add_ct "<nick>"`.
+  //
+  // Multiple entries are allowed for nick variants:
+  //   "MatchByName": ["s1mple", "S1MPLE", "s1mple_bot"]
+  "MatchByName": ["ExamplePro"],
+
+  // Free-form notes for future maintainers. Not displayed at runtime.
+  "Description": "Notes on this player's playstyle and why we chose these traits.",
+
+  // ---- Behavior traits ------------------------------------------------------
+  // All default to false. Each true flag is opted into in a small block in
+  // ProImitator.ApplyPersonality. Setting a trait to false means "don't touch
+  // that part of the bot's behavior" — BotState's generic improvements still
+  // apply.
+  // --------------------------------------------------------------------------
+
+  // Always be in a hurry (HurryTimer maxed every tick). Bot ignores hiding
+  // spots, takes shortest paths, less likely to camp. Pair with NeverPolite
+  // for full-send entry behavior.
+  "AlwaysRushing": false,
+
+  // Never silent-walk (SneakTimer zeroed every tick). Loud, fast traversal.
+  "NeverSneaks": false,
+
+  // Never wait behind teammates (PoliteTimer + IsWaitingBehindFriend cleared).
+  // Bot will push through allies rather than yield in chokepoints.
+  "NeverPolite": false,
+
+  // Force SafeTime = 0 every tick. The bot never feels "safe enough to skip
+  // threat checks" near its spawn. Most pros should have this true.
+  "NoSafeTime": false,
+
+  // Force PanicTimer = 0 every tick. BotState already does this too, but
+  // setting it here means the personality is self-contained if BotState ever
+  // gets unloaded.
+  "NoPanic": false
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -127,5 +127,26 @@
   //             the timing like a real human would
   //
   // Default 0 means the trait is off; pick a value in (0, 1] to enable.
-  "CounterStrafeChance": 0
+  "CounterStrafeChance": 0,
+
+  // KnifeRush: hold the knife during the peaceful early-round rush so the
+  // bot gets the knife's movement bonus (260 u/s vs 215 with a rifle, 200
+  // with the AWP — ~20% faster). Switches back to the role weapon the
+  // moment either:
+  //   - KnifeRushSec elapses (the bot reaches their expected angle), OR
+  //   - the bot enters a duel (IsAimingAtEnemy flips true → bot AI takes
+  //     over, ProImitator stops fighting the weapon switch).
+  //
+  // Real pros do this on every round on de_*: jog out with knife, switch
+  // ~3s before expected contact. The "expected contact" varies by map
+  // and role — an entry T sees enemies at 4-6s, a CT AWPer holding long
+  // at 8-10s — so tune KnifeRushSec to the player's typical first-contact
+  // timing.
+  //
+  // Suggested values:
+  //   4.0-5.0  = aggressive entry / peeker (donk, m0NESY)
+  //   5.5-6.5  = standard rifler (jL, NiKo)
+  //   7.0-8.0  = patient AWPer holding angles (ZywOo)
+  "KnifeRush":    false,
+  "KnifeRushSec": 5.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -84,5 +84,20 @@
   // Pair-with: run `ak47` (or `m4a1` / `aug` etc.) in chat before the round
   // so BotBuy gives every Terrorist / CT an AK / M4. donk will then stick to
   // his rifle even after picking up a Deagle from a corpse.
-  "RifleOnly": false
+  "RifleOnly": false,
+
+  // Counter-strafe at engagement onset. On the false->true edge of
+  // IsAimingAtEnemy, zero the bot's lateral velocity for ~120ms so the
+  // first tap-shot lands with full standing-still accuracy.
+  //
+  // Real human pros do this by tapping the opposite-direction movement key
+  // for 1-3 frames to cancel momentum (left-strafe + brief D-tap = stopped).
+  // We achieve the same observable effect by writing AbsVelocity.X/Y = 0 each
+  // tick during the window. Once the window expires, normal movement resumes,
+  // so a sustained spray fight still has the bot strafing — only the first
+  // shot of an engagement gets the freeze.
+  //
+  // Without this trait the bot run-and-guns and ALWAYS sprays which is
+  // visually wrong for pros who counter-strafe their first taps.
+  "CounterStrafes": false
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -79,37 +79,28 @@
   // and CheckedHidingSpotCount to zero.
   "NoApproachPause": false,
 
-  // "This pro is a rifler." All-or-save rule, observed at round-freeze:
+  // "This pro is a rifler." Pure preference — ProImitator does NOT buy,
+  // give, refund or touch the bot's account. The engine + BotBuy fully
+  // own the economic decisions (eco / semi-buy / full-buy, what weapon to
+  // give, when to refund). All this trait does:
   //
-  //   - Bot has only pistol / SMG / shotgun / nothing → engine called it an
-  //     eco or semi-buy round, ProImitator leaves it alone.
+  //   - Every tick, if the bot is holding a non-rifle (pistol, knife from
+  //     reload-switch, etc) but already owns a rifle in inventory, issue
+  //     `use weapon_<rifle>` to switch the active slot back. If the engine
+  //     never gave the bot a rifle this round, nothing happens — the bot
+  //     plays whatever they have.
   //
-  //   - Bot has a big primary (rifle or sniper) AND can afford the swap to
-  //     the role rifle (AK for T, M4 for CT) → swap. Account is adjusted by
-  //     the PRICE DIFFERENCE: AUG 3300 → M4 2900 refunds 400; Galil 1800 →
-  //     AK 2700 costs 900; AK 2700 → AK 2700 cross-team isn't a thing but
-  //     same-rifle ownership skips the swap entirely (already optimal).
-  //
-  //   - Bot has a big primary but CAN'T afford the swap → REFUND the wrong
-  //     primary and save the money. Without this branch, a Rifler stuck with
-  //     a Krieg (3000) when AK (2700) refund-swap costs nothing wouldn't
-  //     matter, but a Rifler stuck with a Scout (1700) from a force-buy
-  //     round would bleed money round after round. The refund breaks that
-  //     funnel.
-  //
-  // Also, EVERY TICK: if the bot is holding a non-rifle (pistol, SMG, etc)
-  // AND already owns a rifle, `use weapon_<rifle>` switches them back.
   // Rifles classified: AK47, M4A1 / M4A1-S, SG556, AUG, GalilAR, FAMAS.
   //
-  // Don't combine with AWPer in the same profile — they'd both try to swap
-  // primaries on the same tick, and Rifler wins (deterministic but arbitrary).
+  // Don't combine with AWPer in the same profile — only one role bias
+  // makes sense per bot.
   "Rifler": false,
 
-  // AWPer mirror of Rifler. Same all-or-save rule with the AWP as the role
-  // weapon: bot has a big primary AND can afford the AWP swap → swap; bot
-  // has a big primary but CAN'T afford the AWP → refund and save (this is
-  // the fix for the Scout / AUG hoarding funnel); bot has only small
-  // primaries / nothing → leave alone.
+  // AWPer mirror of Rifler. Pure preference: if the engine ever gave the
+  // bot an AWP / SSG08 and they're currently holding something else,
+  // switch back. Otherwise, no-op. We never conjure an AWP for them — if
+  // BotBuy and the engine decide the bot can't afford or shouldn't AWP
+  // this round, we respect that.
   "AWPer": false,
 
   // Counter-strafe at engagement onset, gated by probability. On the

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -79,31 +79,31 @@
   // and CheckedHidingSpotCount to zero.
   "NoApproachPause": false,
 
-  // Force-prefer rifles: every time the bot is holding a non-rifle (pistol,
-  // SMG, sniper, shotgun) AND owns a rifle, issue `use weapon_<rifle>` so the
-  // bot swaps back. Rifles classified: AK47, M4A1/M4A1-S, SG556, AUG,
-  // GalilAR, FAMAS.
+  // "This pro is a rifler." Two coordinated effects, both eco-aware:
   //
-  // Important: this trait does NOT *give* a rifle. The bot has to obtain one
-  // through the normal channels (BotBuy coordinated buy, picking one up off
-  // the ground, getting it from a dropped weapon). That way we don't break
-  // the in-game economy.
+  //   1. AT ROUND-FREEZE: if the bot can afford a full buy (rifle + armor =
+  //      3700$ for T with AK, 3900$ for CT with M4) AND doesn't already own
+  //      a rifle, ProImitator buys their team's main rifle (AK for T, M4
+  //      for CT) and deducts the price from their account.
   //
-  // Pair-with: run `ak47` (or `m4a1` / `aug` etc.) in chat before the round
-  // so BotBuy gives every Terrorist / CT an AK / M4. donk will then stick to
-  // his rifle even after picking up a Deagle from a corpse.
-  "RifleOnly": false,
+  //      Below the full-buy floor → DO NOTHING. The bot falls back to
+  //      whatever BotBuy / the engine bought (pistol round, eco SMG, etc).
+  //      No "stupid" rifle buys on a 2200$ account.
+  //
+  //   2. EVERY TICK: if the bot is holding a non-rifle (pistol, SMG, sniper,
+  //      shotgun) AND owns a rifle, `use weapon_<rifle>` switches them back.
+  //      Rifles classified: AK47, M4A1 / M4A1-S, SG556, AUG, GalilAR, FAMAS.
+  //
+  // Don't combine with AWPer in the same profile — they'd both try to buy a
+  // primary at the same tick, and Rifler wins (deterministic but arbitrary).
+  "Rifler": false,
 
-  // AWPer mirror of RifleOnly. Force-switch back to AWP / SSG08 every time
-  // the bot is holding something else AND owns a sniper. Same no-give
-  // policy: requires the bot to already own the sniper (via the buyscript
-  // or a pickup). Set this true for AWPer profiles so they don't permanently
-  // settle on a teammate's dropped rifle.
-  //
-  // Don't combine with RifleOnly — the two would fight each other every
-  // tick and both wins would cancel out (cooldown protects from spam, but
-  // the bot would never settle).
-  "AwpOnly": false,
+  // AWPer mirror of Rifler. Same eco logic with the AWP full-buy floor at
+  // 5750$ (AWP 4750 + 1000 armor). Same per-tick switch-back if the bot picks
+  // up a teammate's dropped rifle. SSG08 is also classified as a sniper, so
+  // a profiled AWPer with Scout from an early-round eco buy won't be force-
+  // switched out of it.
+  "AWPer": false,
 
   // Counter-strafe at engagement onset, gated by probability. On the
   // false->true edge of IsAimingAtEnemy we roll a die against this chance;

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -139,6 +139,29 @@
   // Default 0 means the trait is off; pick a value in (0, 1] to enable.
   "CounterStrafeChance": 0,
 
+  // BombFocus (V4 — objective awareness): nudges the bot to favour the
+  // round's actual win condition over mid-round fragfest behaviour.
+  //
+  //   T-SIDE:  HurryTimer maxed every tick + CheckedHidingSpotCount=0.
+  //            Bot rushes its assigned bombsite, less stopping for off-
+  //            angle duels at mid. Stacks fine with AlwaysRushing.
+  //
+  //   CT-SIDE: SafeTime set to 8s every tick. Bot holds its assigned site
+  //            rather than peeking out to mid. Opposite of NoSafeTime —
+  //            don't combine the two on a single profile (they fight per
+  //            tick).
+  //
+  // Set true for: Entry Fraggers, IGLs, Supports — anyone who should be
+  //               executing the team plan.
+  // Set false for: Lurkers and AWPers — by design they play away from the
+  //                main objective; BombFocus would erase that.
+  //
+  // What this trait deliberately doesn't do: override the engine's bomb-
+  // site assignment, suppress combat, or path the bot manually. It's a
+  // priority bias on top of CS2's existing scenario logic. See the V4
+  // banner in ProImitator.cs ApplyPersonality for the full design notes.
+  "BombFocus": false,
+
   // KnifeRush: hold the knife during the peaceful early-round rush so the
   // bot gets the knife's movement bonus (260 u/s vs 215 with a rifle, 200
   // with the AWP — ~20% faster). Switches back to the role weapon the

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -15,12 +15,22 @@
   "MatchByName": ["ExamplePro"],
 
   // Display-only role tag, shown in `pro_list`. Purely documentation: does
-  // NOT change behavior. The point is to make a 5-bot roster legible at a
-  // glance ("oh, this team has 2 entries, 1 AWPer, 1 lurker, 1 IGL") and to
-  // remind profile authors to pick a coherent set of traits for the role
-  // they're modelling. Suggested values: "Entry rifler", "Star rifler",
-  // "Lurker", "AWPer", "AWPer (aggressive)", "IGL", "Support".
-  "Role": "Entry rifler",
+  // NOT change behavior. Use the canonical 5 CS2 roles (dmarket taxonomy):
+  //
+  //   "Entry Fragger" — aggressive first-in, breaks defenses
+  //   "Support"       — utility-heavy, enables Entry/AWPer, anchors sites
+  //   "Lurker"        — stealthy independent flanker, gathers info
+  //   "AWPer"         — long-range sniper, picks holds angles
+  //   "IGL"           — coordinator, calls strats, makes economic decisions
+  //
+  // Players often fill 2 roles depending on side / situation. Use a comma:
+  //   "IGL, Support"          (typical for IGLs who play support secondary)
+  //   "Lurker, Entry Fragger" (flexible rifler shifting per round)
+  //   "Entry Fragger, Lurker" (star rifler with solo-flank tendencies)
+  //
+  // Convention: the FIRST role listed is the primary; the second is the
+  // common secondary. Behavioral flags below should match the primary.
+  "Role": "Entry Fragger",
 
   // Free-form notes for future maintainers. Not displayed at runtime.
   "Description": "Notes on this player's playstyle and why we chose these traits.",

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/_template.json
@@ -69,5 +69,20 @@
   // Hyper-aggressive players are already committed before reaching the angle
   // and engage the moment they see an enemy. Sets InhibitLookAroundTimestamp
   // and CheckedHidingSpotCount to zero.
-  "NoApproachPause": false
+  "NoApproachPause": false,
+
+  // Force-prefer rifles: every time the bot is holding a non-rifle (pistol,
+  // SMG, sniper, shotgun) AND owns a rifle, issue `use weapon_<rifle>` so the
+  // bot swaps back. Rifles classified: AK47, M4A1/M4A1-S, SG556, AUG,
+  // GalilAR, FAMAS.
+  //
+  // Important: this trait does NOT *give* a rifle. The bot has to obtain one
+  // through the normal channels (BotBuy coordinated buy, picking one up off
+  // the ground, getting it from a dropped weapon). That way we don't break
+  // the in-game economy.
+  //
+  // Pair-with: run `ak47` (or `m4a1` / `aug` etc.) in chat before the round
+  // so BotBuy gives every Terrorist / CT an AK / M4. donk will then stick to
+  // his rifle even after picking up a Deagle from a corpse.
+  "RifleOnly": false
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/aleksib.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/aleksib.json
@@ -8,10 +8,10 @@
   "Description": "Aleksi 'Aleksib' Virolainen — Finnish veteran IGL of NaVi. ENCE/OG/G2 history. Tactical caller, default-heavy style, builds rounds around utility execution. Plays support rifle behind his stars.",
 
   "AlwaysRushing":          false,
-  "NeverSneaks":            true,
+  "NeverSneaks":            false,
   "NeverPolite":            false,
-  "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoSafeTime":             false,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/aleksib.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/aleksib.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           7.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/aleksib.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/aleksib.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["Aleksib", "aleksib"],
 
-  "Role": "IGL",
+  "Role": "IGL, Support",
 
   "Description": "Aleksi 'Aleksib' Virolainen — Finnish veteran IGL of NaVi. ENCE/OG/G2 history. Tactical caller, default-heavy style, builds rounds around utility execution. Plays support rifle behind his stars.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/aleksib.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/aleksib.json
@@ -1,0 +1,25 @@
+{
+  "Name": "Aleksib",
+
+  "MatchByName": ["Aleksib", "aleksib"],
+
+  "Role": "IGL",
+
+  "Description": "Aleksi 'Aleksib' Virolainen — Finnish veteran IGL of NaVi. ENCE/OG/G2 history. Tactical caller, default-heavy style, builds rounds around utility execution. Plays support rifle behind his stars.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            false,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           7.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/apex.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/apex.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           7.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/apex.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/apex.json
@@ -1,0 +1,25 @@
+{
+  "Name": "apEX",
+
+  "MatchByName": ["apEX", "apex"],
+
+  "Role": "IGL",
+
+  "Description": "Dan 'apEX' Madesclaire — Team Vitality captain and in-game leader. French veteran, the structural backbone of Vitality. Calls plays, coordinates utility, takes calm fragging duties. Not the entry but always within trade range. Pure rifler, plays smart positions, never wastes economy on bad force buys.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            false,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           7.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/apex.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/apex.json
@@ -8,10 +8,10 @@
   "Description": "Dan 'apEX' Madesclaire — Team Vitality captain and in-game leader. French veteran, the structural backbone of Vitality. Calls plays, coordinates utility, takes calm fragging duties. Not the entry but always within trade range. Pure rifler, plays smart positions, never wastes economy on bad force buys.",
 
   "AlwaysRushing":          false,
-  "NeverSneaks":            true,
+  "NeverSneaks":            false,
   "NeverPolite":            false,
-  "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoSafeTime":             false,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/apex.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/apex.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["apEX", "apex"],
 
-  "Role": "IGL",
+  "Role": "IGL, Support",
 
   "Description": "Dan 'apEX' Madesclaire — Team Vitality captain and in-game leader. French veteran, the structural backbone of Vitality. Calls plays, coordinates utility, takes calm fragging duties. Not the entry but always within trade range. Pure rifler, plays smart positions, never wastes economy on bad force buys.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/b1t.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/b1t.json
@@ -8,12 +8,12 @@
   "Description": "Valeriy 'b1t' Vakhovskyi — Ukrainian NaVi prodigy. Precision rifler, clutch potential, plays both star duels and supportive positions. The successor to s1mple's NaVi legacy on rifles.",
 
   "AlwaysRushing":          false,
-  "NeverSneaks":            true,
-  "NeverPolite":            true,
+  "NeverSneaks":            false,
+  "NeverPolite":            false,
   "NoSafeTime":             true,
   "NoPanic":                true,
 
-  "NoCrouchWithRifle":      true,
+  "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,
   "NoApproachPause":        false,
   "Rifler":                 true,
@@ -21,5 +21,5 @@
   "CounterStrafeChance":    0.75,
 
   "KnifeRush":              true,
-  "KnifeRushSec":           6.0
+  "KnifeRushSec":           7.5
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/b1t.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/b1t.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["b1t"],
 
-  "Role": "Star rifler",
+  "Role": "Lurker, Support",
 
   "Description": "Valeriy 'b1t' Vakhovskyi — Ukrainian NaVi prodigy. Precision rifler, clutch potential, plays both star duels and supportive positions. The successor to s1mple's NaVi legacy on rifles.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/b1t.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/b1t.json
@@ -1,0 +1,25 @@
+{
+  "Name": "b1t",
+
+  "MatchByName": ["b1t"],
+
+  "Role": "Star rifler",
+
+  "Description": "Valeriy 'b1t' Vakhovskyi — Ukrainian NaVi prodigy. Precision rifler, clutch potential, plays both star duels and supportive positions. The successor to s1mple's NaVi legacy on rifles.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           6.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/b1t.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/b1t.json
@@ -11,7 +11,7 @@
   "NeverSneaks":            false,
   "NeverPolite":            false,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -18,5 +18,8 @@
   "NoApproachPause":        true,
   "Rifler":                 true,
 
-  "CounterStrafeChance":    0.75
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           5.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["donk"],
 
-  "Description": "Danil 'donk' Kryshkovets — Team Spirit star entry fragger. Hold-W mentality but calculated. Forces raw-aim duels at close to mid range with rifles, no AWP. Rated #1 by HLTV in 2024 as a 17-year-old prodigy. Iconic stand-spray with AK, never crouches with rifles, rifle-only (AK/M4) — never swaps to pistol or SMG when a rifle is available.",
+  "Description": "Danil 'donk' Kryshkovets — Team Spirit star entry fragger. Hold-W mentality but calculated. Forces raw-aim duels at close to mid range with rifles, no AWP. Rated #1 by HLTV in 2024 as a 17-year-old prodigy. Iconic: stand-spray with AK, never crouches with rifles, counter-strafes mid-rush before each first tap, rifle-only (never swaps to pistol/SMG when a rifle is available).",
 
   "AlwaysRushing":          true,
   "NeverSneaks":            true,
@@ -14,5 +14,6 @@
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": true,
   "NoApproachPause":        true,
-  "RifleOnly":              true
+  "RifleOnly":              true,
+  "CounterStrafes":         true
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           5.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -1,0 +1,13 @@
+{
+  "Name": "donk",
+
+  "MatchByName": ["donk"],
+
+  "Description": "Danil 'donk' Kryshkovets — Team Spirit star entry fragger. Hold-W mentality but calculated. Forces raw-aim duels at close to mid range with rifles, no AWP. Rated #1 by HLTV in 2024 as a 17-year-old prodigy.",
+
+  "AlwaysRushing": true,
+  "NeverSneaks":   true,
+  "NeverPolite":   true,
+  "NoSafeTime":    true,
+  "NoPanic":       true
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -3,11 +3,15 @@
 
   "MatchByName": ["donk"],
 
-  "Description": "Danil 'donk' Kryshkovets — Team Spirit star entry fragger. Hold-W mentality but calculated. Forces raw-aim duels at close to mid range with rifles, no AWP. Rated #1 by HLTV in 2024 as a 17-year-old prodigy.",
+  "Description": "Danil 'donk' Kryshkovets — Team Spirit star entry fragger. Hold-W mentality but calculated. Forces raw-aim duels at close to mid range with rifles, no AWP. Rated #1 by HLTV in 2024 as a 17-year-old prodigy. Iconic stand-spray with AK, never crouches with rifles.",
 
-  "AlwaysRushing": true,
-  "NeverSneaks":   true,
-  "NeverPolite":   true,
-  "NoSafeTime":    true,
-  "NoPanic":       true
+  "AlwaysRushing":          true,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": true,
+  "NoApproachPause":        true
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -11,11 +11,11 @@
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        true,
+  "NoApproachPause":        false,
   "Rifler":                 true,
 
   "CounterStrafeChance":    0.75,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -3,6 +3,8 @@
 
   "MatchByName": ["donk"],
 
+  "Role": "Entry rifler",
+
   "Description": "Danil 'donk' Kryshkovets — Team Spirit star entry fragger. Hold-W mentality but calculated. Forces raw-aim duels at close to mid range with rifles, no AWP. Rated #1 by HLTV in 2024 as a 17-year-old prodigy. Iconic: stand-spray with AK, never crouches with rifles, counter-strafes ~75% of the time before each first tap (humans miss the timing sometimes), rifle-only.",
 
   "AlwaysRushing":          true,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -18,5 +18,5 @@
   "NoApproachPause":        true,
   "Rifler":                 true,
 
-  "CounterStrafeChance":    0.65
+  "CounterStrafeChance":    0.75
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["donk"],
 
-  "Description": "Danil 'donk' Kryshkovets — Team Spirit star entry fragger. Hold-W mentality but calculated. Forces raw-aim duels at close to mid range with rifles, no AWP. Rated #1 by HLTV in 2024 as a 17-year-old prodigy. Iconic: stand-spray with AK, never crouches with rifles, counter-strafes mid-rush before each first tap, rifle-only (never swaps to pistol/SMG when a rifle is available).",
+  "Description": "Danil 'donk' Kryshkovets — Team Spirit star entry fragger. Hold-W mentality but calculated. Forces raw-aim duels at close to mid range with rifles, no AWP. Rated #1 by HLTV in 2024 as a 17-year-old prodigy. Iconic: stand-spray with AK, never crouches with rifles, counter-strafes ~75% of the time before each first tap (humans miss the timing sometimes), rifle-only.",
 
   "AlwaysRushing":          true,
   "NeverSneaks":            true,
@@ -12,8 +12,9 @@
   "NoPanic":                true,
 
   "NoCrouchWithRifle":      true,
-  "NeverWaitsBetweenShots": true,
+  "NeverWaitsBetweenShots": false,
   "NoApproachPause":        true,
   "RifleOnly":              true,
-  "CounterStrafes":         true
+
+  "CounterStrafeChance":    0.75
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["donk"],
 
-  "Description": "Danil 'donk' Kryshkovets — Team Spirit star entry fragger. Hold-W mentality but calculated. Forces raw-aim duels at close to mid range with rifles, no AWP. Rated #1 by HLTV in 2024 as a 17-year-old prodigy. Iconic stand-spray with AK, never crouches with rifles.",
+  "Description": "Danil 'donk' Kryshkovets — Team Spirit star entry fragger. Hold-W mentality but calculated. Forces raw-aim duels at close to mid range with rifles, no AWP. Rated #1 by HLTV in 2024 as a 17-year-old prodigy. Iconic stand-spray with AK, never crouches with rifles, rifle-only (AK/M4) — never swaps to pistol or SMG when a rifle is available.",
 
   "AlwaysRushing":          true,
   "NeverSneaks":            true,
@@ -13,5 +13,6 @@
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": true,
-  "NoApproachPause":        true
+  "NoApproachPause":        true,
+  "RifleOnly":              true
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["donk"],
 
-  "Role": "Entry rifler",
+  "Role": "Entry Fragger",
 
   "Description": "Danil 'donk' Kryshkovets — Team Spirit star entry fragger. Hold-W mentality but calculated. Forces raw-aim duels at close to mid range with rifles, no AWP. Rated #1 by HLTV in 2024 as a 17-year-old prodigy. Iconic: stand-spray with AK, never crouches with rifles, counter-strafes ~75% of the time before each first tap (humans miss the timing sometimes), rifle-only.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/donk.json
@@ -16,7 +16,7 @@
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
   "NoApproachPause":        true,
-  "RifleOnly":              true,
+  "Rifler":                 true,
 
-  "CounterStrafeChance":    0.75
+  "CounterStrafeChance":    0.65
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/fallen.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/fallen.json
@@ -8,10 +8,10 @@
   "Description": "Gabriel 'FalleN' Toledo — Brazilian veteran, IGL for FURIA. 'The Professor', Major winner. Calls strats, plays secondary AWP on some rounds but mostly rifles. Decades of CS knowledge translate into patient mid-round adjustments. Never panics.",
 
   "AlwaysRushing":          false,
-  "NeverSneaks":            true,
+  "NeverSneaks":            false,
   "NeverPolite":            false,
-  "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoSafeTime":             false,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/fallen.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/fallen.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           7.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/fallen.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/fallen.json
@@ -1,0 +1,25 @@
+{
+  "Name": "FalleN",
+
+  "MatchByName": ["FalleN", "fallen"],
+
+  "Role": "IGL",
+
+  "Description": "Gabriel 'FalleN' Toledo — Brazilian veteran, IGL for FURIA. 'The Professor', Major winner. Calls strats, plays secondary AWP on some rounds but mostly rifles. Decades of CS knowledge translate into patient mid-round adjustments. Never panics.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            false,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           7.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/fallen.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/fallen.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["FalleN", "fallen"],
 
-  "Role": "IGL",
+  "Role": "IGL, Support",
 
   "Description": "Gabriel 'FalleN' Toledo — Brazilian veteran, IGL for FURIA. 'The Professor', Major winner. Calls strats, plays secondary AWP on some rounds but mostly rifles. Decades of CS knowledge translate into patient mid-round adjustments. Never panics.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/flamez.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/flamez.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["flameZ", "flamez"],
 
-  "Role": "Entry rifler",
+  "Role": "Entry Fragger",
 
   "Description": "Shahar 'flameZ' Shushan — Israeli entry fragger for Vitality. Fearless first-in, high headshot percentage, opens rounds with raw aim. The aggressive piece that gives Vitality numerical superiority before ZywOo and ropz close it out.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/flamez.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/flamez.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           5.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/flamez.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/flamez.json
@@ -11,11 +11,11 @@
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        true,
+  "NoApproachPause":        false,
   "Rifler":                 true,
 
   "CounterStrafeChance":    0.75,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/flamez.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/flamez.json
@@ -1,0 +1,25 @@
+{
+  "Name": "flameZ",
+
+  "MatchByName": ["flameZ", "flamez"],
+
+  "Role": "Entry rifler",
+
+  "Description": "Shahar 'flameZ' Shushan — Israeli entry fragger for Vitality. Fearless first-in, high headshot percentage, opens rounds with raw aim. The aggressive piece that gives Vitality numerical superiority before ZywOo and ropz close it out.",
+
+  "AlwaysRushing":          true,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        true,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           5.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/im.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/im.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           5.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/im.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/im.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["iM", "im"],
 
-  "Role": "Star rifler",
+  "Role": "Entry Fragger",
 
   "Description": "Mihai 'iM' Ivan — Romanian dynamic rifler, joined NaVi from GamerLegion. Aggressive star duels, second piece in the trade chain. High peak rounds, willing to take 50/50s.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/im.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/im.json
@@ -11,11 +11,11 @@
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        true,
+  "NoApproachPause":        false,
   "Rifler":                 true,
 
   "CounterStrafeChance":    0.75,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/im.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/im.json
@@ -1,0 +1,25 @@
+{
+  "Name": "iM",
+
+  "MatchByName": ["iM", "im"],
+
+  "Role": "Star rifler",
+
+  "Description": "Mihai 'iM' Ivan — Romanian dynamic rifler, joined NaVi from GamerLegion. Aggressive star duels, second piece in the trade chain. High peak rounds, willing to take 50/50s.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           5.5
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/im.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/im.json
@@ -7,7 +7,7 @@
 
   "Description": "Mihai 'iM' Ivan — Romanian dynamic rifler, joined NaVi from GamerLegion. Aggressive star duels, second piece in the trade chain. High peak rounds, willing to take 50/50s.",
 
-  "AlwaysRushing":          false,
+  "AlwaysRushing":          true,
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
@@ -15,11 +15,11 @@
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        false,
+  "NoApproachPause":        true,
   "Rifler":                 true,
 
   "CounterStrafeChance":    0.75,
 
   "KnifeRush":              true,
-  "KnifeRushSec":           5.5
+  "KnifeRushSec":           5.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
@@ -18,5 +18,5 @@
   "NoApproachPause":        true,
   "Rifler":                 true,
 
-  "CounterStrafeChance":    0.72
+  "CounterStrafeChance":    0.75
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           5.5
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
@@ -16,7 +16,7 @@
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
   "NoApproachPause":        true,
-  "RifleOnly":              true,
+  "Rifler":                 true,
 
-  "CounterStrafeChance":    0.85
+  "CounterStrafeChance":    0.72
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
@@ -11,11 +11,11 @@
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        true,
+  "NoApproachPause":        false,
   "Rifler":                 true,
 
   "CounterStrafeChance":    0.75,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
@@ -18,5 +18,8 @@
   "NoApproachPause":        true,
   "Rifler":                 true,
 
-  "CounterStrafeChance":    0.75
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           5.5
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["jL", "jl"],
 
-  "Role": "Entry rifler",
+  "Role": "Entry Fragger",
 
   "Description": "Justinas 'jL' Lekavicius — Vitality entry / support rifler. Same opener-mentality as donk but cleaner movement: he commits to the entry but is less of a hold-W animal. Slightly less aggressive crouch-stand identity (he WILL crouch behind a Deagle / pistol-round pop), and a higher counter-strafe success rate because his fragging style is more methodical than donk's chaos.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/jL.json
@@ -1,0 +1,22 @@
+{
+  "Name": "jL",
+
+  "MatchByName": ["jL", "jl"],
+
+  "Role": "Entry rifler",
+
+  "Description": "Justinas 'jL' Lekavicius — Vitality entry / support rifler. Same opener-mentality as donk but cleaner movement: he commits to the entry but is less of a hold-W animal. Slightly less aggressive crouch-stand identity (he WILL crouch behind a Deagle / pistol-round pop), and a higher counter-strafe success rate because his fragging style is more methodical than donk's chaos.",
+
+  "AlwaysRushing":          true,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        true,
+  "RifleOnly":              true,
+
+  "CounterStrafeChance":    0.85
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/karrigan.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/karrigan.json
@@ -8,10 +8,10 @@
   "Description": "Finn 'karrigan' Andersen — Danish legendary IGL, ex-FaZe captain. Joined Falcons April 2026 replacing kyxsan. Veteran strategist, mid-round adjustments, never tilts. Rifle support — plays smart positions and lets his stars (NiKo, m0NESY) get the picks.",
 
   "AlwaysRushing":          false,
-  "NeverSneaks":            true,
+  "NeverSneaks":            false,
   "NeverPolite":            false,
-  "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoSafeTime":             false,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/karrigan.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/karrigan.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           7.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/karrigan.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/karrigan.json
@@ -1,0 +1,25 @@
+{
+  "Name": "karrigan",
+
+  "MatchByName": ["karrigan"],
+
+  "Role": "IGL",
+
+  "Description": "Finn 'karrigan' Andersen — Danish legendary IGL, ex-FaZe captain. Joined Falcons April 2026 replacing kyxsan. Veteran strategist, mid-round adjustments, never tilts. Rifle support — plays smart positions and lets his stars (NiKo, m0NESY) get the picks.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            false,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           7.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/karrigan.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/karrigan.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["karrigan"],
 
-  "Role": "IGL",
+  "Role": "IGL, Support",
 
   "Description": "Finn 'karrigan' Andersen — Danish legendary IGL, ex-FaZe captain. Joined Falcons April 2026 replacing kyxsan. Veteran strategist, mid-round adjustments, never tilts. Rifle support — plays smart positions and lets his stars (NiKo, m0NESY) get the picks.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/kscerato.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/kscerato.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["KSCERATO", "kscerato"],
 
-  "Role": "Star rifler",
+  "Role": "Entry Fragger, Support",
 
   "Description": "Kaike 'KSCERATO' Cerato — Brazilian star rifler, FURIA's other consistent firepower alongside yuurih. Clean stand-spray, takes star duels, anchors sites on defense. Together with yuurih the rifling core that has defined FURIA's best periods.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/kscerato.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/kscerato.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           5.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/kscerato.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/kscerato.json
@@ -11,11 +11,11 @@
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        true,
+  "NoApproachPause":        false,
   "Rifler":                 true,
 
   "CounterStrafeChance":    0.75,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/kscerato.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/kscerato.json
@@ -1,0 +1,25 @@
+{
+  "Name": "KSCERATO",
+
+  "MatchByName": ["KSCERATO", "kscerato"],
+
+  "Role": "Star rifler",
+
+  "Description": "Kaike 'KSCERATO' Cerato — Brazilian star rifler, FURIA's other consistent firepower alongside yuurih. Clean stand-spray, takes star duels, anchors sites on defense. Together with yuurih the rifling core that has defined FURIA's best periods.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           6.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/kscerato.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/kscerato.json
@@ -7,7 +7,7 @@
 
   "Description": "Kaike 'KSCERATO' Cerato — Brazilian star rifler, FURIA's other consistent firepower alongside yuurih. Clean stand-spray, takes star duels, anchors sites on defense. Together with yuurih the rifling core that has defined FURIA's best periods.",
 
-  "AlwaysRushing":          false,
+  "AlwaysRushing":          true,
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
@@ -15,11 +15,11 @@
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        false,
+  "NoApproachPause":        true,
   "Rifler":                 true,
 
   "CounterStrafeChance":    0.75,
 
   "KnifeRush":              true,
-  "KnifeRushSec":           6.0
+  "KnifeRushSec":           5.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/kyousuke.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/kyousuke.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           5.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/kyousuke.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/kyousuke.json
@@ -1,0 +1,25 @@
+{
+  "Name": "kyousuke",
+
+  "MatchByName": ["kyousuke"],
+
+  "Role": "Entry rifler",
+
+  "Description": "Maxim 'kyousuke' Lukin — 18-year-old Russian aim freak, Falcons entry fragger. Youngest member of a Tier-1 team. High opener success, low clutch — pure first-duel specialist. Hold-W with surgical aim.",
+
+  "AlwaysRushing":          true,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        true,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           5.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/kyousuke.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/kyousuke.json
@@ -11,11 +11,11 @@
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        true,
+  "NoApproachPause":        false,
   "Rifler":                 true,
 
   "CounterStrafeChance":    0.75,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/kyousuke.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/kyousuke.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["kyousuke"],
 
-  "Role": "Entry rifler",
+  "Role": "Entry Fragger",
 
   "Description": "Maxim 'kyousuke' Lukin — 18-year-old Russian aim freak, Falcons entry fragger. Youngest member of a Tier-1 team. High opener success, low clutch — pure first-duel specialist. Hold-W with surgical aim.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/magixx.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/magixx.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           7.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/magixx.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/magixx.json
@@ -1,0 +1,25 @@
+{
+  "Name": "magixx",
+
+  "MatchByName": ["magixx"],
+
+  "Role": "IGL",
+
+  "Description": "Boris 'magixx' Vorobiev — Russian rifler, new Spirit captain. Returned to the active roster late 2025. Calls rounds while rifling, builds the team around donk's entry firepower.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            false,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           7.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/magixx.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/magixx.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["magixx"],
 
-  "Role": "IGL",
+  "Role": "IGL, Support",
 
   "Description": "Boris 'magixx' Vorobiev — Russian rifler, new Spirit captain. Returned to the active roster late 2025. Calls rounds while rifling, builds the team around donk's entry firepower.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/magixx.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/magixx.json
@@ -8,10 +8,10 @@
   "Description": "Boris 'magixx' Vorobiev — Russian rifler, new Spirit captain. Returned to the active roster late 2025. Calls rounds while rifling, builds the team around donk's entry firepower.",
 
   "AlwaysRushing":          false,
-  "NeverSneaks":            true,
+  "NeverSneaks":            false,
   "NeverPolite":            false,
-  "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoSafeTime":             false,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/makazze.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/makazze.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           4.5
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/makazze.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/makazze.json
@@ -1,0 +1,25 @@
+{
+  "Name": "makazze",
+
+  "MatchByName": ["makazze"],
+
+  "Role": "Entry rifler",
+
+  "Description": "Drin 'makazze' Shaqiri — 19-year-old Kosovo hyper-aggressive entry. From NAVI Junior to main roster July 2025. ESL Pro League S23 MVP. Pure space-taker — pushes forward, forces rotations, opens rounds.",
+
+  "AlwaysRushing":          true,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        true,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           4.5
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/makazze.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/makazze.json
@@ -11,11 +11,11 @@
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        true,
+  "NoApproachPause":        false,
   "Rifler":                 true,
 
   "CounterStrafeChance":    0.75,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/makazze.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/makazze.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["makazze"],
 
-  "Role": "Entry rifler",
+  "Role": "Entry Fragger",
 
   "Description": "Drin 'makazze' Shaqiri — 19-year-old Kosovo hyper-aggressive entry. From NAVI Junior to main roster July 2025. ESL Pro League S23 MVP. Pure space-taker — pushes forward, forces rotations, opens rounds.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/mezii.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/mezii.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           6.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/mezii.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/mezii.json
@@ -8,10 +8,10 @@
   "Description": "William 'mezii' Merriman — British support rifler for Vitality. Anchors hard sites, prioritises utility (flashes, mollies, smokes for teammates). Versatile second-in on attack and primary anchor on defense. Stats less flashy than ZywOo/ropz but consistent trade kills make Vitality's structure work.",
 
   "AlwaysRushing":          false,
-  "NeverSneaks":            true,
+  "NeverSneaks":            false,
   "NeverPolite":            false,
-  "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoSafeTime":             false,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/mezii.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/mezii.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["mezii"],
 
-  "Role": "Support rifler",
+  "Role": "Support",
 
   "Description": "William 'mezii' Merriman — British support rifler for Vitality. Anchors hard sites, prioritises utility (flashes, mollies, smokes for teammates). Versatile second-in on attack and primary anchor on defense. Stats less flashy than ZywOo/ropz but consistent trade kills make Vitality's structure work.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/mezii.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/mezii.json
@@ -1,0 +1,25 @@
+{
+  "Name": "mezii",
+
+  "MatchByName": ["mezii"],
+
+  "Role": "Support rifler",
+
+  "Description": "William 'mezii' Merriman — British support rifler for Vitality. Anchors hard sites, prioritises utility (flashes, mollies, smokes for teammates). Versatile second-in on attack and primary anchor on defense. Stats less flashy than ZywOo/ropz but consistent trade kills make Vitality's structure work.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            false,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           6.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/molodoy.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/molodoy.json
@@ -11,7 +11,7 @@
   "NeverSneaks":            false,
   "NeverPolite":            true,
   "NoSafeTime":             false,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/molodoy.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/molodoy.json
@@ -1,0 +1,26 @@
+{
+  "Name": "molodoy",
+
+  "MatchByName": ["molodoy"],
+
+  "Role": "AWPer",
+
+  "Description": "FURIA's primary AWPer. Elite clutch-round performer, the sniper closing rounds. Patient holding angles, picks the right peeks. Plays the role disciplined — saves the AWP rather than half-buying.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            false,
+  "NeverPolite":            true,
+  "NoSafeTime":             false,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 false,
+  "AWPer":                  true,
+
+  "CounterStrafeChance":    0.85,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           7.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
@@ -11,11 +11,11 @@
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        true,
+  "NoApproachPause":        false,
   "Rifler":                 false,
   "AWPer":                  true,
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["m0NESY", "monesy"],
 
-  "Role": "AWPer (aggressive)",
+  "Role": "AWPer",
 
   "Description": "Ilya 'm0NESY' Osipov — G2 star AWPer. Aggressive read of the AWP role: takes early-round map control with the AWP, peeks more often than he holds, runs onto angles. Closer in feel to a rifler's tempo than ZywOo's patient holds. Hence AlwaysRushing + NoApproachPause + NeverPolite, but kept AwpOnly so he never drops to the secondary rifle when he has the AWP.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
@@ -19,5 +19,8 @@
   "Rifler":                 false,
   "AWPer":                  true,
 
-  "CounterStrafeChance":    0.85
+  "CounterStrafeChance":    0.85,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           4.5
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
@@ -19,5 +19,5 @@
   "Rifler":                 false,
   "AWPer":                  true,
 
-  "CounterStrafeChance":    0.70
+  "CounterStrafeChance":    0.85
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
@@ -1,0 +1,23 @@
+{
+  "Name": "m0NESY",
+
+  "MatchByName": ["m0NESY", "monesy"],
+
+  "Role": "AWPer (aggressive)",
+
+  "Description": "Ilya 'm0NESY' Osipov — G2 star AWPer. Aggressive read of the AWP role: takes early-round map control with the AWP, peeks more often than he holds, runs onto angles. Closer in feel to a rifler's tempo than ZywOo's patient holds. Hence AlwaysRushing + NoApproachPause + NeverPolite, but kept AwpOnly so he never drops to the secondary rifle when he has the AWP.",
+
+  "AlwaysRushing":          true,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        true,
+  "RifleOnly":              false,
+  "AwpOnly":                true,
+
+  "CounterStrafeChance":    0.80
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/monesy.json
@@ -16,8 +16,8 @@
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,
   "NoApproachPause":        true,
-  "RifleOnly":              false,
-  "AwpOnly":                true,
+  "Rifler":                 false,
+  "AWPer":                  true,
 
-  "CounterStrafeChance":    0.80
+  "CounterStrafeChance":    0.70
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["NiKo", "niko"],
 
-  "Role": "Star rifler",
+  "Role": "Entry Fragger, Lurker",
 
   "Description": "Nikola 'NiKo' Kovac — FaZe / G2 veteran star rifler. NOT an entry: he plays second/third in the trade chain, takes mid-range duels with surgical aim, prefers M4/AK over AWP. We drop AlwaysRushing and NoApproachPause (he uses cover and waits at angles), keep rifle-only and the stand-spray identity. Highest counter-strafe rate of the rifle group: his shots are famously the cleanest of his generation.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
@@ -1,0 +1,22 @@
+{
+  "Name": "NiKo",
+
+  "MatchByName": ["NiKo", "niko"],
+
+  "Role": "Star rifler",
+
+  "Description": "Nikola 'NiKo' Kovac — FaZe / G2 veteran star rifler. NOT an entry: he plays second/third in the trade chain, takes mid-range duels with surgical aim, prefers M4/AK over AWP. We drop AlwaysRushing and NoApproachPause (he uses cover and waits at angles), keep rifle-only and the stand-spray identity. Highest counter-strafe rate of the rifle group: his shots are famously the cleanest of his generation.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "RifleOnly":              true,
+
+  "CounterStrafeChance":    0.90
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
@@ -11,7 +11,7 @@
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           5.5
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
@@ -7,7 +7,7 @@
 
   "Description": "Nikola 'NiKo' Kovac — FaZe / G2 veteran star rifler. NOT an entry: he plays second/third in the trade chain, takes mid-range duels with surgical aim, prefers M4/AK over AWP. We drop AlwaysRushing and NoApproachPause (he uses cover and waits at angles), keep rifle-only and the stand-spray identity. Highest counter-strafe rate of the rifle group: his shots are famously the cleanest of his generation.",
 
-  "AlwaysRushing":          false,
+  "AlwaysRushing":          true,
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
@@ -21,5 +21,5 @@
   "CounterStrafeChance":    0.75,
 
   "KnifeRush":              true,
-  "KnifeRushSec":           6.5
+  "KnifeRushSec":           5.5
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
@@ -18,5 +18,8 @@
   "NoApproachPause":        false,
   "Rifler":                 true,
 
-  "CounterStrafeChance":    0.75
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           6.5
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
@@ -16,7 +16,7 @@
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
   "NoApproachPause":        false,
-  "RifleOnly":              true,
+  "Rifler":                 true,
 
-  "CounterStrafeChance":    0.90
+  "CounterStrafeChance":    0.78
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/niko.json
@@ -18,5 +18,5 @@
   "NoApproachPause":        false,
   "Rifler":                 true,
 
-  "CounterStrafeChance":    0.78
+  "CounterStrafeChance":    0.75
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/ropz.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/ropz.json
@@ -11,7 +11,7 @@
   "NeverSneaks":            false,
   "NeverPolite":            false,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/ropz.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/ropz.json
@@ -1,0 +1,25 @@
+{
+  "Name": "ropz",
+
+  "MatchByName": ["ropz"],
+
+  "Role": "Lurker",
+
+  "Description": "Robin 'ropz' Kool — Estonian lurker, ex-FaZe veteran. HLTV #3 in 2025. Meticulous timing-based flanks, 1v2/1v3 clutch master. Plays solo on the flank to catch rotators, prefers slow methodical pace, never overextends. He sneaks, he waits, then takes the duel that breaks the round.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            false,
+  "NeverPolite":            false,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           7.5
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/sh1ro.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/sh1ro.json
@@ -11,7 +11,7 @@
   "NeverSneaks":            false,
   "NeverPolite":            true,
   "NoSafeTime":             false,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/sh1ro.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/sh1ro.json
@@ -1,0 +1,26 @@
+{
+  "Name": "sh1ro",
+
+  "MatchByName": ["sh1ro"],
+
+  "Role": "AWPer",
+
+  "Description": "Dmitry 'sh1ro' Sokolov — Russian world-class AWPer. Ex-Gambit/Cloud9 dynasty. The 'closer' role in Spirit — holds angles, takes the last AWP shot of the round. Patient, methodical, low-tilt.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            false,
+  "NeverPolite":            true,
+  "NoSafeTime":             false,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 false,
+  "AWPer":                  true,
+
+  "CounterStrafeChance":    0.85,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           7.5
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/teses.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/teses.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           6.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/teses.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/teses.json
@@ -1,0 +1,25 @@
+{
+  "Name": "TeSeS",
+
+  "MatchByName": ["TeSeS", "teses"],
+
+  "Role": "Anchor",
+
+  "Description": "René 'TeSeS' Madsen — Danish rifler for Falcons. Small-site anchor on CT (often B Mirage), second-in on T, reliable mid-round voice. High-trust support role on a star-heavy lineup — frees up NiKo and m0NESY to take their duels.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            false,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           6.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/teses.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/teses.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["TeSeS", "teses"],
 
-  "Role": "Anchor",
+  "Role": "Support",
 
   "Description": "René 'TeSeS' Madsen — Danish rifler for Falcons. Small-site anchor on CT (often B Mirage), second-in on T, reliable mid-round voice. High-trust support role on a star-heavy lineup — frees up NiKo and m0NESY to take their duels.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/teses.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/teses.json
@@ -8,10 +8,10 @@
   "Description": "René 'TeSeS' Madsen — Danish rifler for Falcons. Small-site anchor on CT (often B Mirage), second-in on T, reliable mid-round voice. High-trust support role on a star-heavy lineup — frees up NiKo and m0NESY to take their duels.",
 
   "AlwaysRushing":          false,
-  "NeverSneaks":            true,
+  "NeverSneaks":            false,
   "NeverPolite":            false,
-  "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoSafeTime":             false,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/tn1r.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/tn1r.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["tN1R", "tn1r"],
 
-  "Role": "Lurker",
+  "Role": "Lurker, Support",
 
   "Description": "Andrey 'tN1R' Tatarinovich — Belarusian rifler joined Spirit September 2025 from HEROIC. T-side lurker, CT anchor, supports donk. 73/100 HLTV clutch rating — the closer when rounds break down.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/tn1r.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/tn1r.json
@@ -11,7 +11,7 @@
   "NeverSneaks":            false,
   "NeverPolite":            false,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/tn1r.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/tn1r.json
@@ -1,0 +1,25 @@
+{
+  "Name": "tN1R",
+
+  "MatchByName": ["tN1R", "tn1r"],
+
+  "Role": "Lurker",
+
+  "Description": "Andrey 'tN1R' Tatarinovich — Belarusian rifler joined Spirit September 2025 from HEROIC. T-side lurker, CT anchor, supports donk. 73/100 HLTV clutch rating — the closer when rounds break down.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            false,
+  "NeverPolite":            false,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           7.5
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/w0nderful.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/w0nderful.json
@@ -11,7 +11,7 @@
   "NeverSneaks":            false,
   "NeverPolite":            true,
   "NoSafeTime":             false,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/w0nderful.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/w0nderful.json
@@ -1,0 +1,26 @@
+{
+  "Name": "w0nderful",
+
+  "MatchByName": ["w0nderful", "wonderful"],
+
+  "Role": "AWPer",
+
+  "Description": "Ihor 'w0nderful' Zhdanov — Ukrainian AWP prodigy, joined NaVi 2023. Patient hold of long angles, picks his peeks carefully. Disciplined AWP buys — never half-buys with Scout when AWP is out of budget.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            false,
+  "NeverPolite":            true,
+  "NoSafeTime":             false,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 false,
+  "AWPer":                  true,
+
+  "CounterStrafeChance":    0.85,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           7.5
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/yekindar.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/yekindar.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["YEKINDAR", "yekindar"],
 
-  "Role": "Entry rifler",
+  "Role": "Entry Fragger",
 
   "Description": "Mareks 'YEKINDAR' Gaļinskis — Latvian aggressive entry, ex-Liquid star. Hyper-aggressive opening duels, fearless commit, adds a new dimension to FURIA's attacking game. The hold-W energy of the squad.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/yekindar.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/yekindar.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           4.5
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/yekindar.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/yekindar.json
@@ -11,11 +11,11 @@
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        true,
+  "NoApproachPause":        false,
   "Rifler":                 true,
 
   "CounterStrafeChance":    0.75,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/yekindar.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/yekindar.json
@@ -1,0 +1,25 @@
+{
+  "Name": "YEKINDAR",
+
+  "MatchByName": ["YEKINDAR", "yekindar"],
+
+  "Role": "Entry rifler",
+
+  "Description": "Mareks 'YEKINDAR' Gaļinskis — Latvian aggressive entry, ex-Liquid star. Hyper-aggressive opening duels, fearless commit, adds a new dimension to FURIA's attacking game. The hold-W energy of the squad.",
+
+  "AlwaysRushing":          true,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        true,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           4.5
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/yuurih.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/yuurih.json
@@ -1,0 +1,25 @@
+{
+  "Name": "yuurih",
+
+  "MatchByName": ["yuurih"],
+
+  "Role": "Star rifler",
+
+  "Description": "Yuri 'yuurih' Santos — Brazilian star rifler, longest-tenured FURIA member. Consistent firepower, plays both entry and second-in depending on call. Stand-spray identity with rifles, never timid in duels.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           6.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/yuurih.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/yuurih.json
@@ -8,12 +8,12 @@
   "Description": "Yuri 'yuurih' Santos — Brazilian star rifler, longest-tenured FURIA member. Consistent firepower, plays both entry and second-in depending on call. Stand-spray identity with rifles, never timid in duels.",
 
   "AlwaysRushing":          false,
-  "NeverSneaks":            true,
-  "NeverPolite":            true,
+  "NeverSneaks":            false,
+  "NeverPolite":            false,
   "NoSafeTime":             true,
   "NoPanic":                true,
 
-  "NoCrouchWithRifle":      true,
+  "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,
   "NoApproachPause":        false,
   "Rifler":                 true,
@@ -21,5 +21,5 @@
   "CounterStrafeChance":    0.75,
 
   "KnifeRush":              true,
-  "KnifeRushSec":           6.0
+  "KnifeRushSec":           7.5
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/yuurih.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/yuurih.json
@@ -11,7 +11,7 @@
   "NeverSneaks":            false,
   "NeverPolite":            false,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/yuurih.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/yuurih.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["yuurih"],
 
-  "Role": "Star rifler",
+  "Role": "Lurker, Entry Fragger",
 
   "Description": "Yuri 'yuurih' Santos — Brazilian star rifler, longest-tenured FURIA member. Consistent firepower, plays both entry and second-in depending on call. Stand-spray identity with rifles, never timid in duels.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/zont1x.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/zont1x.json
@@ -20,6 +20,8 @@
 
   "CounterStrafeChance":    0.75,
 
+  "BombFocus":              true,
+
   "KnifeRush":              true,
   "KnifeRushSec":           5.0
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/zont1x.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/zont1x.json
@@ -1,0 +1,25 @@
+{
+  "Name": "zont1x",
+
+  "MatchByName": ["zont1x"],
+
+  "Role": "Entry rifler",
+
+  "Description": "Myroslav 'zont1x' Plakhotia — Ukrainian entry rifler, returned to Spirit late 2025. Space-taker alongside donk on T-side. Aggressive opener, opens up rounds with raw aim.",
+
+  "AlwaysRushing":          true,
+  "NeverSneaks":            true,
+  "NeverPolite":            true,
+  "NoSafeTime":             true,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      true,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        true,
+  "Rifler":                 true,
+
+  "CounterStrafeChance":    0.75,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           5.0
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/zont1x.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/zont1x.json
@@ -11,11 +11,11 @@
   "NeverSneaks":            true,
   "NeverPolite":            true,
   "NoSafeTime":             true,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      true,
   "NeverWaitsBetweenShots": false,
-  "NoApproachPause":        true,
+  "NoApproachPause":        false,
   "Rifler":                 true,
 
   "CounterStrafeChance":    0.75,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/zont1x.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/zont1x.json
@@ -3,7 +3,7 @@
 
   "MatchByName": ["zont1x"],
 
-  "Role": "Entry rifler",
+  "Role": "Entry Fragger",
 
   "Description": "Myroslav 'zont1x' Plakhotia — Ukrainian entry rifler, returned to Spirit late 2025. Space-taker alongside donk on T-side. Aggressive opener, opens up rounds with raw aim.",
 

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/zywoo.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/zywoo.json
@@ -19,5 +19,5 @@
   "Rifler":                 false,
   "AWPer":                  true,
 
-  "CounterStrafeChance":    0.75
+  "CounterStrafeChance":    0.85
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/zywoo.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/zywoo.json
@@ -11,7 +11,7 @@
   "NeverSneaks":            false,
   "NeverPolite":            true,
   "NoSafeTime":             false,
-  "NoPanic":                true,
+  "NoPanic":                false,
 
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/zywoo.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/zywoo.json
@@ -16,8 +16,8 @@
   "NoCrouchWithRifle":      false,
   "NeverWaitsBetweenShots": false,
   "NoApproachPause":        false,
-  "RifleOnly":              false,
-  "AwpOnly":                true,
+  "Rifler":                 false,
+  "AWPer":                  true,
 
-  "CounterStrafeChance":    0.85
+  "CounterStrafeChance":    0.75
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/zywoo.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/zywoo.json
@@ -19,5 +19,8 @@
   "Rifler":                 false,
   "AWPer":                  true,
 
-  "CounterStrafeChance":    0.85
+  "CounterStrafeChance":    0.85,
+
+  "KnifeRush":              true,
+  "KnifeRushSec":           7.5
 }

--- a/addons/counterstrikesharp/plugins/ProImitator/profiles/zywoo.json
+++ b/addons/counterstrikesharp/plugins/ProImitator/profiles/zywoo.json
@@ -1,0 +1,23 @@
+{
+  "Name": "ZywOo",
+
+  "MatchByName": ["ZywOo", "zywoo"],
+
+  "Role": "AWPer",
+
+  "Description": "Mathieu 'ZywOo' Herbaut — Vitality star AWPer, multiple-time HLTV #1. Patient, position-driven, holds angles from spawn and times peeks rather than running them. NOT rushing, NOT skipping approach pauses (he WANTS those long holds). AwpOnly forces him back to the AWP whenever he picks up a teammate's rifle off the floor. Counter-strafe is high but not perfect — even ZywOo occasionally peeks running.",
+
+  "AlwaysRushing":          false,
+  "NeverSneaks":            false,
+  "NeverPolite":            true,
+  "NoSafeTime":             false,
+  "NoPanic":                true,
+
+  "NoCrouchWithRifle":      false,
+  "NeverWaitsBetweenShots": false,
+  "NoApproachPause":        false,
+  "RifleOnly":              false,
+  "AwpOnly":                true,
+
+  "CounterStrafeChance":    0.85
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/toggle_cs2_install.ps1
+++ b/addons/counterstrikesharp/plugins/ProImitator/toggle_cs2_install.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+  Active ou desactive ProImitator dans l'install CS2, sans toucher au reste.
+
+.DESCRIPTION
+  - 'enable'  : copie ProImitator.dll + profiles/ depuis bin/Release/net8.0/
+                vers csgo/addons/counterstrikesharp/plugins/ProImitator/
+  - 'disable' : supprime le dossier ProImitator du dossier plugins de CS2
+  - 'status'  : indique si le plugin est actuellement installe
+
+  Aucun autre plugin de la suite (BotAI, BotState, BotAimImprover...) n'est
+  touche. Le plugin est juste "drop-in / drop-out".
+
+.PARAMETER Action
+  enable | disable | status (default: status)
+
+.EXAMPLE
+  .\toggle_cs2_install.ps1 enable
+  .\toggle_cs2_install.ps1 disable
+  .\toggle_cs2_install.ps1 status
+#>
+
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet("enable", "disable", "status")]
+    [string]$Action = "status"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Chemins
+$pluginDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$buildOut  = Join-Path $pluginDir "bin\Release\net8.0"
+$cs2Plugins = "C:\Program Files (x86)\Steam\steamapps\common\Counter-Strike Global Offensive\game\csgo\addons\counterstrikesharp\plugins"
+$cs2Dest   = Join-Path $cs2Plugins "ProImitator"
+
+function Write-Section($msg) {
+    Write-Host ""
+    Write-Host "=== $msg ===" -ForegroundColor Cyan
+}
+
+if (-not (Test-Path $cs2Plugins)) {
+    Write-Host "[!!] CS2 plugins folder introuvable : $cs2Plugins" -ForegroundColor Red
+    Write-Host "     Verifie que CS2 + CounterStrikeSharp sont installes."
+    exit 1
+}
+
+switch ($Action) {
+
+    "status" {
+        Write-Section "Status ProImitator dans CS2"
+        if (Test-Path $cs2Dest) {
+            Write-Host "[OK] INSTALLE dans $cs2Dest" -ForegroundColor Green
+            Get-ChildItem $cs2Dest -Recurse | ForEach-Object {
+                Write-Host "     $($_.FullName.Substring($cs2Dest.Length+1))"
+            }
+        } else {
+            Write-Host "[--] PAS INSTALLE" -ForegroundColor Yellow
+            Write-Host "     CS2 utilise les plugins originaux ed0ard/CS2-Bot-Improver uniquement."
+        }
+    }
+
+    "enable" {
+        Write-Section "Enable ProImitator dans CS2"
+        if (-not (Test-Path $buildOut)) {
+            Write-Host "[!!] Build output introuvable : $buildOut" -ForegroundColor Red
+            Write-Host "     Lance d'abord : dotnet build -c Release"
+            exit 1
+        }
+
+        # Cleanup + recreate
+        if (Test-Path $cs2Dest) {
+            Remove-Item -Recurse -Force $cs2Dest
+        }
+        New-Item -ItemType Directory -Force -Path $cs2Dest | Out-Null
+
+        # Copy DLL + deps + pdb + profiles
+        Copy-Item -Path (Join-Path $buildOut "ProImitator.dll")       -Destination $cs2Dest
+        Copy-Item -Path (Join-Path $buildOut "ProImitator.deps.json") -Destination $cs2Dest
+        if (Test-Path (Join-Path $buildOut "ProImitator.pdb")) {
+            Copy-Item -Path (Join-Path $buildOut "ProImitator.pdb") -Destination $cs2Dest
+        }
+        Copy-Item -Recurse -Path (Join-Path $buildOut "profiles") -Destination $cs2Dest -Force
+
+        Write-Host "[OK] Installe dans $cs2Dest" -ForegroundColor Green
+        Write-Host ""
+        Write-Host "Si CS2 tourne, recharge le plugin sans restart serveur :"
+        Write-Host "  css_plugins reload ProImitator" -ForegroundColor Yellow
+    }
+
+    "disable" {
+        Write-Section "Disable ProImitator dans CS2"
+        if (-not (Test-Path $cs2Dest)) {
+            Write-Host "[--] Pas installe, rien a faire" -ForegroundColor Yellow
+            exit 0
+        }
+
+        Remove-Item -Recurse -Force $cs2Dest
+        Write-Host "[OK] Supprime de $cs2Dest" -ForegroundColor Green
+        Write-Host ""
+        Write-Host "Les autres plugins (BotAI, BotState, BotAimImprover, ...) sont intacts."
+        Write-Host "Si CS2 tourne, unload via console :"
+        Write-Host "  css_plugins unload ProImitator" -ForegroundColor Yellow
+    }
+}

--- a/addons/counterstrikesharp/plugins/ProImitator/toggle_cs2_install.ps1
+++ b/addons/counterstrikesharp/plugins/ProImitator/toggle_cs2_install.ps1
@@ -1,15 +1,21 @@
 <#
 .SYNOPSIS
-  Active ou desactive ProImitator dans l'install CS2, sans toucher au reste.
+  Enable or disable ProImitator inside the CS2 install, without touching
+  the rest of the ed0ard/CS2-Bot-Improver suite.
 
 .DESCRIPTION
-  - 'enable'  : copie ProImitator.dll + profiles/ depuis bin/Release/net8.0/
-                vers csgo/addons/counterstrikesharp/plugins/ProImitator/
-  - 'disable' : supprime le dossier ProImitator du dossier plugins de CS2
-  - 'status'  : indique si le plugin est actuellement installe
+  - 'enable'  : copies ProImitator.dll + profiles/ from bin/Release/net8.0/
+                into csgo/addons/counterstrikesharp/plugins/ProImitator/
+  - 'disable' : removes the ProImitator folder from the CS2 plugins dir
+  - 'status'  : reports whether the plugin is currently installed
 
-  Aucun autre plugin de la suite (BotAI, BotState, BotAimImprover...) n'est
-  touche. Le plugin est juste "drop-in / drop-out".
+  None of the other plugins in the suite (BotAI, BotState, BotAimImprover,
+  BotBuy, BotRandomizer, NadeSystem, RoundDamageRecap) are touched. The
+  plugin is a clean drop-in / drop-out.
+
+  Developer convenience script — intentionally hardcoded to a single CS2
+  install path (Steam default on Windows). Edit `$cs2Plugins` below if your
+  install is elsewhere.
 
 .PARAMETER Action
   enable | disable | status (default: status)
@@ -28,7 +34,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-# Chemins
+# Paths
 $pluginDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $buildOut  = Join-Path $pluginDir "bin\Release\net8.0"
 $cs2Plugins = "C:\Program Files (x86)\Steam\steamapps\common\Counter-Strike Global Offensive\game\csgo\addons\counterstrikesharp\plugins"
@@ -40,31 +46,31 @@ function Write-Section($msg) {
 }
 
 if (-not (Test-Path $cs2Plugins)) {
-    Write-Host "[!!] CS2 plugins folder introuvable : $cs2Plugins" -ForegroundColor Red
-    Write-Host "     Verifie que CS2 + CounterStrikeSharp sont installes."
+    Write-Host "[!!] CS2 plugins folder not found: $cs2Plugins" -ForegroundColor Red
+    Write-Host "     Verify that CS2 + CounterStrikeSharp are installed."
     exit 1
 }
 
 switch ($Action) {
 
     "status" {
-        Write-Section "Status ProImitator dans CS2"
+        Write-Section "ProImitator status in CS2"
         if (Test-Path $cs2Dest) {
-            Write-Host "[OK] INSTALLE dans $cs2Dest" -ForegroundColor Green
+            Write-Host "[OK] INSTALLED at $cs2Dest" -ForegroundColor Green
             Get-ChildItem $cs2Dest -Recurse | ForEach-Object {
                 Write-Host "     $($_.FullName.Substring($cs2Dest.Length+1))"
             }
         } else {
-            Write-Host "[--] PAS INSTALLE" -ForegroundColor Yellow
-            Write-Host "     CS2 utilise les plugins originaux ed0ard/CS2-Bot-Improver uniquement."
+            Write-Host "[--] NOT INSTALLED" -ForegroundColor Yellow
+            Write-Host "     CS2 is running the original ed0ard/CS2-Bot-Improver suite only."
         }
     }
 
     "enable" {
-        Write-Section "Enable ProImitator dans CS2"
+        Write-Section "Enable ProImitator in CS2"
         if (-not (Test-Path $buildOut)) {
-            Write-Host "[!!] Build output introuvable : $buildOut" -ForegroundColor Red
-            Write-Host "     Lance d'abord : dotnet build -c Release"
+            Write-Host "[!!] Build output not found: $buildOut" -ForegroundColor Red
+            Write-Host "     Run first: dotnet build -c Release"
             exit 1
         }
 
@@ -82,24 +88,24 @@ switch ($Action) {
         }
         Copy-Item -Recurse -Path (Join-Path $buildOut "profiles") -Destination $cs2Dest -Force
 
-        Write-Host "[OK] Installe dans $cs2Dest" -ForegroundColor Green
+        Write-Host "[OK] Installed at $cs2Dest" -ForegroundColor Green
         Write-Host ""
-        Write-Host "Si CS2 tourne, recharge le plugin sans restart serveur :"
+        Write-Host "If CS2 is running, hot-reload without restarting the server:"
         Write-Host "  css_plugins reload ProImitator" -ForegroundColor Yellow
     }
 
     "disable" {
-        Write-Section "Disable ProImitator dans CS2"
+        Write-Section "Disable ProImitator in CS2"
         if (-not (Test-Path $cs2Dest)) {
-            Write-Host "[--] Pas installe, rien a faire" -ForegroundColor Yellow
+            Write-Host "[--] Not installed, nothing to do" -ForegroundColor Yellow
             exit 0
         }
 
         Remove-Item -Recurse -Force $cs2Dest
-        Write-Host "[OK] Supprime de $cs2Dest" -ForegroundColor Green
+        Write-Host "[OK] Removed from $cs2Dest" -ForegroundColor Green
         Write-Host ""
-        Write-Host "Les autres plugins (BotAI, BotState, BotAimImprover, ...) sont intacts."
-        Write-Host "Si CS2 tourne, unload via console :"
+        Write-Host "The other plugins (BotAI, BotState, BotAimImprover, ...) are intact."
+        Write-Host "If CS2 is running, unload via console:"
         Write-Host "  css_plugins unload ProImitator" -ForegroundColor Yellow
     }
 }


### PR DESCRIPTION
[README.md](https://github.com/user-attachments/files/28485628/README.md)

## Summary

Adds **ProImitator**, a new CounterStrikeSharp plugin that layers per-bot personality presets on top of the existing suite. When a bot spawns via `bot_add_ct "ZywOo"` (or any name listed in a profile's `MatchByName`), the plugin reads `profiles/<pro>.json` and applies a coherent set of behavioural biases each tick so the bot starts to *play* like that pro.

Ships with **26 ready-to-use profiles** covering the 2026 rosters of Vitality, FURIA, Falcons, NaVi and Spirit. Spectate a round of "Vitality vs Spirit on Dust2" and the bots fragment into recognisable roles — donk rushing site, sh1ro holding long, apEX coordinating from second-in.

## What's new

- 🆕 **`addons/counterstrikesharp/plugins/ProImitator/`** — single-file C# plugin (~1100 LOC) + 26 JSON profiles + comprehensive README
- 🎯 **5-role taxonomy** (Entry Fragger / Support / Lurker / AWPer / IGL) following the [dmarket CS2 roles guide](https://dmarket.com/blog/cs2-roles-guide/) — every team has full role coverage
- 🧠 **13 trait flags** that map to `CCSBot` schema writes (HurryTimer, SneakTimer, SafeTime, etc.) — opt-in per profile
- 📦 **BombFocus** — pre/post-plant role inversion, bomb-carrier extra push, dropped-bomb CT defence
- 🔪 **KnifeRush** — distance-gated knife hold (≈20% movement bonus) when no opponent within 1500u
- 🛒 **Strict role-buy** — AK / M4 / AWP at round-freeze if the bot has the full price in cash, otherwise no buy (no fake-money refund credits)
- 🔧 **AK pickup preference** — CTs that pick up an AK off a dead T keep it through subsequent rounds instead of force-buying their M4 back
- 👀 **`pro_debug` command** — toggles in-game chat logging of round / per-bot events for observability

## Roster coverage

| Team       | Bots                                                              |
|------------|-------------------------------------------------------------------|
| Vitality   | apEX, ZywOo, ropz, mezii, flameZ                                  |
| FURIA      | FalleN, yuurih, KSCERATO, YEKINDAR, molodoy                       |
| Falcons    | karrigan, NiKo, m0NESY, TeSeS, kyousuke                           |
| NaVi       | Aleksib, iM, b1t, w0nderful, makazze                              |
| Spirit     | magixx, sh1ro, tN1R, zont1x, donk                                 |

Roster + role information cross-referenced from HLTV team pages and Liquipedia. Multi-role bots use a comma-separated `Role` field (e.g. `"IGL, Support"`); the primary role drives the behavioural template.

## What it does — and what it deliberately does **not**

| It does                                                                  | It does **not** |
|--------------------------------------------------------------------------|-----------------|
| Pick a profile based on the bot's in-game name at spawn                  | Override the global `bot_aim` style (use `bot_aim head` manually) |
| Apply trait-driven per-tick writes to `CCSBot` schema fields             | Patch the CS2 binary (that's `BotAI`'s job) |
| Buy the role's preferred weapon if the bot has the cash                  | Refund-then-buy (no fake money) |
| Swap to the role weapon when the bot is holding something else           | Hook native `PickNewAimSpot` (that's `BotAimImprover`'s job) |
| Track pre/post-plant phase and invert attacker/defender roles            | Override the engine's bombsite assignment |
| Hold the knife between angles when no opponent is in combat range        | Drive pathing or waypoint following (no nav-mesh override) |
| Detect a dropped bomb and harden CT defence around it                    | Distribute CTs across A / B / mid (engine handles that) |

The plugin is fully **additive** — only writes properties that are either left alone by `BotState` or that `BotState` sets to the same value (e.g. `PanicTimer = 0`). It never fights another plugin's intent.

## Public commands

No `css_` prefix → no admin permission required (same UX as `bot_aim` / `bot_nades`).

| Command         | Effect                                              |
|-----------------|-----------------------------------------------------|
| `pro_list`      | List all profiles loaded from disk                  |
| `pro_assigned`  | List bots that currently have a profile attached    |
| `pro_reload`    | Re-read profiles from disk after editing JSON       |
| `pro_debug`     | Toggle verbose chat logging for behaviour events    |

## Quick test — Vitality (CT) vs Spirit (T) on Dust2

```
map de_dust2
```

(wait for the map to load, then paste in one go)

```
sv_cheats 1; mp_warmuptime 0; mp_warmup_end; mp_maxrounds 24; mp_overtime_enable 1;
mp_match_can_clinch 1; bot_difficulty 3; mp_friendlyfire 0; mp_autoteambalance 0;
mp_limitteams 0; bot_kick; pro_reload;
bot_add_ct "apEX"; bot_add_ct "ZywOo"; bot_add_ct "ropz"; bot_add_ct "mezii"; bot_add_ct "flameZ";
mp_teamlogo_1 vita; mp_teamname_1 Team Vitality;
bot_add_t "donk"; bot_add_t "zont1x"; bot_add_t "magixx"; bot_add_t "tN1R"; bot_add_t "sh1ro";
mp_teamlogo_2 spir; mp_teamname_2 Spirit;
mp_restartgame 3; pro_assigned; jointeam 1
```

Observable behaviours:
- Bots hold knives while traversing (no opponent in 1500u radius), pull weapons on approach
- Bomb carrier alternates run / walk on ~3-second windows (50/50 coinflip)
- Pre-plant CTs hold their assigned sites; post-plant the roles invert (Ts hold the plant, CTs push to defuse)
- Dropped C4 → CTs within 1500u of the bomb position hold harder (`SafeTime` 9s vs the standard 6s defender bias)

## Files

```
addons/counterstrikesharp/plugins/ProImitator/
├── README.md                  ← full design discussion + trait reference
├── ProImitator.cs             ← single-file C# implementation
├── ProImitator.csproj         ← build config
├── toggle_cs2_install.ps1     ← dev helper (drop-in / drop-out from CS2 install)
└── profiles/
    ├── _template.json         ← field-by-field documentation
    └── (26 pro profile JSONs)
```

See [the plugin's README](addons/counterstrikesharp/plugins/ProImitator/README.md) for the full trait reference, architecture (V1 → V4.8), and guide for adding new pros.

## Notes for review

- **No changes to existing files** — the PR is purely additive. `BotState`, `BotAI`, `BotBuy`, `BotAimImprover`, `BotRandomizer`, `NadeSystem`, `RoundDamageRecap` are untouched.
- The dev helper script (`toggle_cs2_install.ps1`) hardcodes the Steam default install path on Windows; feel free to drop it from the merge if you don't want it shipped.
- All code comments are in English and intentionally verbose — they document trade-offs, calibration history (V4.1 → V4.8) and what was deliberately not done, so future contributors can pick up the trait system without spelunking through git log.

By **Ouistiti**.