### PR TITLE
chore: Bump Panel/release version to v1.4.2

### DIFF
--- a/Panel/package.json
+++ b/Panel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cs2-bot-improver-panel",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/Panel/src/components/TitleBar.tsx
+++ b/Panel/src/components/TitleBar.tsx
@@ -8,7 +8,7 @@ type Props = {
   onSettings: () => void;
 };
 
-export default function TitleBar({ title = "CS2 Bot Improver v1.4.0", onSettings }: Props) {
+export default function TitleBar({ title = "CS2 Bot Improver v1.4.2", onSettings }: Props) {
   const appWindow = getCurrentWindow();
   const t = useT();
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Aims to enhance your experience when playing against bots offline or with friend
 
    (If you run a dedicated server that is not only for bot matches, please download **CS2BotImprover_rules_unchanged.zip**)
 
-2. Put **Panel v1.4.1.exe** anywhere convenient
+2. Put **Panel v1.4.2.exe** anywhere convenient
 
 <img width="128" height="128" alt="App" src="https://github.com/user-attachments/assets/7271dc7d-2436-484b-8359-6531f4abd710" />
 
@@ -40,7 +40,7 @@ Aims to enhance your experience when playing against bots offline or with friend
 
 <img width="540" height="181" alt="snap_windows" src="https://github.com/user-attachments/assets/6a8645fc-78e7-4f3a-92d3-5d1b6d913918" />
 
-4. Open **Panel v1.4.1.exe**, select **Bot Mode**, then click **Launch CS2** 
+4. Open **Panel v1.4.2.exe**, select **Bot Mode**, then click **Launch CS2** 
 
 <img width="339" height="129" alt="Panel_1" src="https://github.com/user-attachments/assets/dc806991-c940-43cf-a614-f49012fae4a7" />
 


### PR DESCRIPTION
## Summary

Bumps the Panel/release version to **v1.4.2** so a new release can be cut that includes the Windows signature fix for the 2026-07-09 game update (8c71b49, BotAimImprover 2.1.3) — the current v1.4.1 release is broken on Windows since that update.

Changes:
- `Panel/package.json`: 1.4.0 → 1.4.2
- `Panel/src/components/TitleBar.tsx`: title updated to "CS2 Bot Improver v1.4.2"
- `README.md`: Panel exe references updated to v1.4.2

Verified the Panel frontend still builds (`tsc && vite build`).

## Suggested v1.4.2 release notes

1. Fixed Windows signatures broken by the 2026-07-09 CS2 update (thanks @yuanyuan829!). BotAimImprover updated to 2.1.3 with wildcard signatures for better resilience to future updates.
2. Fixed a max money bug in BotBuy.
3. Added Gentle Mates player profiles.
4. Updated competitive mode cfg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)