### PR TITLE
加入中文伤害显示

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Bots have minimal limitations and think less before throwing nades
 `bot_nades`  
 Shows the current nade throwing mode
 
+### Damage Recap
+
+- `css_damage_style`: Shows the current round-end damage recap style
+- `css_damage_style classic`: Uses the existing English damage recap format (default)
+- `css_damage_style pw`: Uses a compact Perfect World-style Chinese format with highlighted numeric values
+
 ### Buy
 
 Input the weapon's name in your console to give every bot this weapon from the next round

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Shows the current nade throwing mode
 ### Damage Recap
 
 - `css_damage_style`: Shows the current round-end damage recap style
-- `css_damage_style classic`: Uses the existing English damage recap format (default)
+- `css_damage_style auto`: Uses `pw` for Chinese player languages and `classic` for other languages (default)
+- `css_damage_style classic`: Always uses the existing English damage recap format
 - `css_damage_style pw`: Uses a compact Perfect World-style Chinese format with highlighted numeric values
 
 ### Buy

--- a/addons/counterstrikesharp/plugins/RoundDamageRecap/RoundDamageRecap.cs
+++ b/addons/counterstrikesharp/plugins/RoundDamageRecap/RoundDamageRecap.cs
@@ -2,6 +2,7 @@ using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
+using CounterStrikeSharp.API.Core.Translations;
 using CounterStrikeSharp.API.Modules.Commands;
 using CounterStrikeSharp.API.Modules.Utils;
 using System.Security.Cryptography;
@@ -21,7 +22,7 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
 
     private readonly Dictionary<int, Dictionary<int, DamageEntry>> _damageByAttacker = new();
     private readonly Dictionary<int, PlayerSnapshot> _playersByKey = new();
-    private DamageRecapStyle _damageStyle = DamageRecapStyle.Classic;
+    private DamageRecapStyle _damageStyle = DamageRecapStyle.Auto;
     private bool _announcedDifficultyThisMap;
 
     public override void Load(bool hotReload)
@@ -30,7 +31,7 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
         RegisterEventHandler<EventPlayerHurt>(OnPlayerHurt);
         RegisterEventHandler<EventRoundEnd>(OnRoundEnd);
         RegisterEventHandler<EventPlayerDisconnect>(OnPlayerDisconnect);
-        AddCommand("css_damage_style", "Set round damage recap style: classic or pw", OnDamageStyleCommand);
+        AddCommand("css_damage_style", "Set round damage recap style: auto, classic or pw", OnDamageStyleCommand);
         RegisterListener<Listeners.OnMapStart>(_ =>
         {
             _damageByAttacker.Clear();
@@ -124,11 +125,19 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
         {
             if (!TryParseDamageStyle(command.GetArg(1), out var style))
             {
-                command.ReplyToCommand("[RoundDamageRecap] usage: css_damage_style <classic|pw>");
+                command.ReplyToCommand("[RoundDamageRecap] usage: css_damage_style <auto|classic|pw>");
                 return;
             }
 
             _damageStyle = style;
+        }
+
+        if (_damageStyle == DamageRecapStyle.Auto && caller is { IsValid: true })
+        {
+            var language = caller.GetLanguage();
+            command.ReplyToCommand(
+                $"[RoundDamageRecap] damage style = auto, effective = {GetDamageStyleName(ResolveDamageStyle(caller))}, language = {language.Name}");
+            return;
         }
 
         command.ReplyToCommand($"[RoundDamageRecap] damage style = {GetDamageStyleName(_damageStyle)}");
@@ -147,6 +156,7 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
             .OrderByDescending(p => GetDamageBetween(player, p).TotalDamage + GetDamageBetween(p, player).TotalDamage)
             .ThenBy(p => p.PlayerName, StringComparer.OrdinalIgnoreCase)
             .ToList();
+        var damageStyle = ResolveDamageStyle(player);
 
         foreach (var enemy in enemyPlayers)
         {
@@ -154,7 +164,7 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
             var fromEntry = GetDamageBetween(enemy, player);
             var remainingHp = GetDisplayedHealth(enemy, toEntry);
 
-            PrintDamageRecapLine(player, enemy.PlayerName, toEntry, fromEntry, remainingHp);
+            PrintDamageRecapLine(player, enemy.PlayerName, toEntry, fromEntry, remainingHp, damageStyle);
         }
     }
 
@@ -163,9 +173,10 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
         string enemyName,
         DamageEntry dealt,
         DamageEntry taken,
-        int remainingHp)
+        int remainingHp,
+        DamageRecapStyle damageStyle)
     {
-        if (_damageStyle == DamageRecapStyle.Classic)
+        if (damageStyle == DamageRecapStyle.Classic)
         {
             PrintLbtvLine(
                 player,
@@ -186,6 +197,12 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
 
     private static bool TryParseDamageStyle(string value, out DamageRecapStyle style)
     {
+        if (value.Equals("auto", StringComparison.OrdinalIgnoreCase))
+        {
+            style = DamageRecapStyle.Auto;
+            return true;
+        }
+
         if (value.Equals("classic", StringComparison.OrdinalIgnoreCase))
         {
             style = DamageRecapStyle.Classic;
@@ -198,13 +215,30 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
             return true;
         }
 
-        style = DamageRecapStyle.Classic;
+        style = DamageRecapStyle.Auto;
         return false;
+    }
+
+    private DamageRecapStyle ResolveDamageStyle(CCSPlayerController player)
+    {
+        if (_damageStyle != DamageRecapStyle.Auto)
+        {
+            return _damageStyle;
+        }
+
+        return player.GetLanguage().TwoLetterISOLanguageName.Equals("zh", StringComparison.OrdinalIgnoreCase)
+            ? DamageRecapStyle.PerfectWorld
+            : DamageRecapStyle.Classic;
     }
 
     private static string GetDamageStyleName(DamageRecapStyle style)
     {
-        return style == DamageRecapStyle.PerfectWorld ? "pw" : "classic";
+        return style switch
+        {
+            DamageRecapStyle.PerfectWorld => "pw",
+            DamageRecapStyle.Classic => "classic",
+            _ => "auto"
+        };
     }
 
     private static void PrintLbtvLine(CCSPlayerController player, string text)
@@ -415,6 +449,7 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
 
     private enum DamageRecapStyle
     {
+        Auto,
         Classic,
         PerfectWorld
     }

--- a/addons/counterstrikesharp/plugins/RoundDamageRecap/RoundDamageRecap.cs
+++ b/addons/counterstrikesharp/plugins/RoundDamageRecap/RoundDamageRecap.cs
@@ -2,6 +2,7 @@ using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
+using CounterStrikeSharp.API.Modules.Commands;
 using CounterStrikeSharp.API.Modules.Utils;
 using System.Security.Cryptography;
 
@@ -11,8 +12,8 @@ namespace RoundDamageRecap;
 public sealed class RoundDamageRecapPlugin : BasePlugin
 {
     public override string ModuleName => "RoundDamageRecap";
-    public override string ModuleVersion => "1.2.0";
-    public override string ModuleAuthor => "YuGeYu (modified by ed0ard)";
+    public override string ModuleVersion => "1.3.0";
+    public override string ModuleAuthor => "YuGeYu (modified by ed0ard and unicbm)";
     public override string ModuleDescription => "Shows a round-end damage recap and current difficulty in chat.";
 
     private const string ChatColorGreen = "\u0006";
@@ -20,6 +21,7 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
 
     private readonly Dictionary<int, Dictionary<int, DamageEntry>> _damageByAttacker = new();
     private readonly Dictionary<int, PlayerSnapshot> _playersByKey = new();
+    private DamageRecapStyle _damageStyle = DamageRecapStyle.Classic;
     private bool _announcedDifficultyThisMap;
 
     public override void Load(bool hotReload)
@@ -28,6 +30,7 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
         RegisterEventHandler<EventPlayerHurt>(OnPlayerHurt);
         RegisterEventHandler<EventRoundEnd>(OnRoundEnd);
         RegisterEventHandler<EventPlayerDisconnect>(OnPlayerDisconnect);
+        AddCommand("css_damage_style", "Set round damage recap style: classic or pw", OnDamageStyleCommand);
         RegisterListener<Listeners.OnMapStart>(_ =>
         {
             _damageByAttacker.Clear();
@@ -115,6 +118,22 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
         return HookResult.Continue;
     }
 
+    private void OnDamageStyleCommand(CCSPlayerController? caller, CommandInfo command)
+    {
+        if (command.ArgCount > 1)
+        {
+            if (!TryParseDamageStyle(command.GetArg(1), out var style))
+            {
+                command.ReplyToCommand("[RoundDamageRecap] usage: css_damage_style <classic|pw>");
+                return;
+            }
+
+            _damageStyle = style;
+        }
+
+        command.ReplyToCommand($"[RoundDamageRecap] damage style = {GetDamageStyleName(_damageStyle)}");
+    }
+
     private void PrintRecapForPlayer(CCSPlayerController player)
     {
         var enemyTeam = GetEnemyTeam(player.Team);
@@ -135,12 +154,57 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
             var fromEntry = GetDamageBetween(enemy, player);
             var remainingHp = GetDisplayedHealth(enemy, toEntry);
 
+            PrintDamageRecapLine(player, enemy.PlayerName, toEntry, fromEntry, remainingHp);
+        }
+    }
+
+    private void PrintDamageRecapLine(
+        CCSPlayerController player,
+        string enemyName,
+        DamageEntry dealt,
+        DamageEntry taken,
+        int remainingHp)
+    {
+        if (_damageStyle == DamageRecapStyle.Classic)
+        {
             PrintLbtvLine(
                 player,
-                $"{enemy.PlayerName} [{(remainingHp > 0 ? $"{remainingHp} HP left" : "DEAD")}] - " +
-                $"Dealt to: [{toEntry.TotalDamage} in {toEntry.HitCount} {(toEntry.HitCount <= 1 ? "hit" : "hits")}] - " +
-                $"Taken from: [{fromEntry.TotalDamage} in {fromEntry.HitCount} {(fromEntry.HitCount <= 1 ? "hit" : "hits")}]");
+                $"{enemyName} [{(remainingHp > 0 ? $"{remainingHp} HP left" : "DEAD")}] - " +
+                $"Dealt to: [{dealt.TotalDamage} in {dealt.HitCount} {(dealt.HitCount <= 1 ? "hit" : "hits")}] - " +
+                $"Taken from: [{taken.TotalDamage} in {taken.HitCount} {(taken.HitCount <= 1 ? "hit" : "hits")}]");
+            return;
         }
+
+        player.PrintToChat(
+            $" {ChatColorDefault}命中{ChatColorGreen}{dealt.HitCount}{ChatColorDefault}次 " +
+            $"{ChatColorGreen}{dealt.TotalDamage}{ChatColorDefault}伤害 " +
+            $"被击中{ChatColorGreen}{taken.HitCount}{ChatColorDefault}次 " +
+            $"{ChatColorGreen}{taken.TotalDamage}{ChatColorDefault}伤害 " +
+            $"剩{ChatColorGreen}{Math.Max(0, remainingHp)}{ChatColorDefault}HP " +
+            $"{enemyName}{ChatColorDefault}");
+    }
+
+    private static bool TryParseDamageStyle(string value, out DamageRecapStyle style)
+    {
+        if (value.Equals("classic", StringComparison.OrdinalIgnoreCase))
+        {
+            style = DamageRecapStyle.Classic;
+            return true;
+        }
+
+        if (value.Equals("pw", StringComparison.OrdinalIgnoreCase))
+        {
+            style = DamageRecapStyle.PerfectWorld;
+            return true;
+        }
+
+        style = DamageRecapStyle.Classic;
+        return false;
+    }
+
+    private static string GetDamageStyleName(DamageRecapStyle style)
+    {
+        return style == DamageRecapStyle.PerfectWorld ? "pw" : "classic";
     }
 
     private static void PrintLbtvLine(CCSPlayerController player, string text)
@@ -348,4 +412,10 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
     private sealed record DifficultyProfile(string Name, string Level, string Path);
 
     private sealed record DifficultyResult(string Name, string Level);
+
+    private enum DamageRecapStyle
+    {
+        Classic,
+        PerfectWorld
+    }
 }

--- a/addons/counterstrikesharp/plugins/RoundDamageRecap/RoundDamageRecap.cs
+++ b/addons/counterstrikesharp/plugins/RoundDamageRecap/RoundDamageRecap.cs
@@ -17,7 +17,8 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
     public override string ModuleAuthor => "YuGeYu (modified by ed0ard and unicbm)";
     public override string ModuleDescription => "Shows a round-end damage recap and current difficulty in chat.";
 
-    private const string ChatColorGreen = "\u0006";
+    private const string ChatColorGreen = "\u0004";
+    private const string ChatColorLime = "\u0006";
     private const string ChatColorDefault = "\u0001";
 
     private readonly Dictionary<int, Dictionary<int, DamageEntry>> _damageByAttacker = new();
@@ -192,7 +193,7 @@ public sealed class RoundDamageRecapPlugin : BasePlugin
             $"被击中{ChatColorGreen}{taken.HitCount}{ChatColorDefault}次 " +
             $"{ChatColorGreen}{taken.TotalDamage}{ChatColorDefault}伤害 " +
             $"剩{ChatColorGreen}{Math.Max(0, remainingHp)}{ChatColorDefault}HP " +
-            $"{enemyName}{ChatColorDefault}");
+            $"{ChatColorLime}{enemyName}{ChatColorDefault}");
     }
 
     private static bool TryParseDamageStyle(string value, out DamageRecapStyle style)


### PR DESCRIPTION
<img width="576" height="196" alt="Perfect World-style damage recap" src="https://github.com/user-attachments/assets/156ca498-88d4-4951-9ead-ecc0fd54dcde" />

- 新增 `css_damage_style` 指令，用于查询和切换伤害显示样式。
- `css_damage_style auto`：根据 CounterStrikeSharp 返回的玩家语言自动选择样式；简体和繁体中文使用 `pw`，其他语言使用 `classic`，并作为默认模式。
- `css_damage_style classic`：始终使用原有英文格式。
- `css_damage_style pw`：始终使用类似完美平台的紧凑中文格式。
- 不改变原有伤害统计和排序逻辑。

## 验证

- Release 编译通过，0 warnings / 0 errors。
- 常见简体、繁体中文 CultureInfo 均可识别为中文。
- `pw` 样式已在 CS2 中实际测试。
