### PR TITLE
Remove native bot look drift

### DIFF
--- a/addons/counterstrikesharp/plugins/BotAI/BotAI.cs
+++ b/addons/counterstrikesharp/plugins/BotAI/BotAI.cs
@@ -25,7 +25,7 @@ public static class BotOffsets
 public class BotAI : BasePlugin
 {
     public override string ModuleName => "Patches - Bot AI";
-    public override string ModuleVersion => "1.8.6";
+    public override string ModuleVersion => "1.8.7";
     public override string ModuleAuthor => "K4ryuu & Austin (updated by ed0ard & Misaka17032 & XBribo & AmagiReina)";
     public override string ModuleDescription =>
         "Improve and fix bots' behavior comprehensively";

--- a/addons/counterstrikesharp/plugins/BotAI/WindowsPatchDefinitions.cs
+++ b/addons/counterstrikesharp/plugins/BotAI/WindowsPatchDefinitions.cs
@@ -6,6 +6,23 @@ internal static class WindowsPatchDefinitions
         new Dictionary<string, (string signature, string patch, string expectedOriginal, int patchOffset)>()
     {
 
+        // CCSBot::Upkeep adds two bot-specific trig results to its persistent
+        // look offsets every tick. Replace only those two calls with 0.0f;
+        // global trigonometry helpers and the rest of native aiming stay intact.
+        ["Upkeep_BotCOS_ZeroDrift"] = (
+            signature: "48 8B 05 ? ? ? ? F3 0F 10 40 30 F3 0F 59 05 ? ? ? ? E8 ? ? ? ? F3 0F 59 C6 F3 0F 58 87 94 59 00 00 F3 0F 11 87 94 59 00 00",
+            patch: "0F 57 C0 90 90",
+            expectedOriginal: "E8 ? ? ? ?",
+            patchOffset: 20
+        ),
+
+        ["Upkeep_BotSIN_ZeroDrift"] = (
+            signature: "48 8B 05 ? ? ? ? F3 0F 10 40 30 F3 0F 59 05 ? ? ? ? E8 ? ? ? ? F3 0F 59 C6 F3 0F 58 87 8C 59 00 00 F3 0F 11 87 8C 59 00 00",
+            patch: "0F 57 C0 90 90",
+            expectedOriginal: "E8 ? ? ? ?",
+            patchOffset: 20
+        ),
+
         // Force HasVisitedEnemySpawn = 1 so bots don't revisit enemy spawn
         ["HasVisitedEnemySpawn"] = (
         signature: "40 88 B7 20 05 00 00",

--- a/addons/counterstrikesharp/plugins/BotAI/WindowsPatchDefinitions.cs
+++ b/addons/counterstrikesharp/plugins/BotAI/WindowsPatchDefinitions.cs
@@ -6,23 +6,6 @@ internal static class WindowsPatchDefinitions
         new Dictionary<string, (string signature, string patch, string expectedOriginal, int patchOffset)>()
     {
 
-        // CCSBot::Upkeep adds two bot-specific trig results to its persistent
-        // look offsets every tick. Replace only those two calls with 0.0f;
-        // global trigonometry helpers and the rest of native aiming stay intact.
-        ["Upkeep_BotCOS_ZeroDrift"] = (
-            signature: "48 8B 05 ? ? ? ? F3 0F 10 40 30 F3 0F 59 05 ? ? ? ? E8 ? ? ? ? F3 0F 59 C6 F3 0F 58 87 94 59 00 00 F3 0F 11 87 94 59 00 00",
-            patch: "0F 57 C0 90 90",
-            expectedOriginal: "E8 ? ? ? ?",
-            patchOffset: 20
-        ),
-
-        ["Upkeep_BotSIN_ZeroDrift"] = (
-            signature: "48 8B 05 ? ? ? ? F3 0F 10 40 30 F3 0F 59 05 ? ? ? ? E8 ? ? ? ? F3 0F 59 C6 F3 0F 58 87 8C 59 00 00 F3 0F 11 87 8C 59 00 00",
-            patch: "0F 57 C0 90 90",
-            expectedOriginal: "E8 ? ? ? ?",
-            patchOffset: 20
-        ),
-
         // Force HasVisitedEnemySpawn = 1 so bots don't revisit enemy spawn
         ["HasVisitedEnemySpawn"] = (
         signature: "40 88 B7 20 05 00 00",
@@ -282,6 +265,29 @@ internal static class WindowsPatchDefinitions
         patch: "B0 01 90",
         expectedOriginal: "0F 96 C0",
         patchOffset: 0
+        ),
+
+
+        // CCSBot::Upkeep adds two bot-specific trig results to its persistent
+        // look offsets every tick. Replace only those two calls with 0.0f;
+        // global trigonometry helpers and the rest of native aiming stay intact.
+        // Source: CCSBot::UpdateLookAngles view-"drift" (cs_bot_update.cpp):
+        //   if (!IsUsingSniperRifle()) {
+        //     m_lookYaw   += driftAmplitude * BotCOS(33.0f * curtime);   // COS
+        //     m_lookPitch += driftAmplitude * BotSIN(13.0f * curtime);   // SIN
+        //   }
+        ["Upkeep_BotCOS_ZeroDrift"] = (
+            signature: "F3 0F 10 35 ? ? ? ? 48 8B 05 ? ? ? ? F3 0F 10 40 30 F3 0F 59 05 ? ? ? ? E8 ? ? ? ? F3 0F 59 C6 F3 0F 58 87 ? ? 00 00 F3 0F 11 87 ? ? 00 00",
+            patch: "0F 57 C0 90 90",
+            expectedOriginal: "E8 ? ? ? ?",
+            patchOffset: 28
+        ),
+
+        ["Upkeep_BotSIN_ZeroDrift"] = (
+            signature: "F3 0F 11 87 ? ? 00 00 48 8B 05 ? ? ? ? F3 0F 10 40 30 F3 0F 59 05 ? ? ? ? E8 ? ? ? ? F3 0F 59 C6 F3 0F 58 87 ? ? 00 00 F3 0F 11 87 ? ? 00 00",
+            patch: "0F 57 C0 90 90",
+            expectedOriginal: "E8 ? ? ? ?",
+            patchOffset: 28
         ),
 
 


### PR DESCRIPTION
## 改动内容

- 在 `CCSBot::Upkeep` 内，将 BotCOS 和 BotSIN 两处调用产生的视角偏移归零。
- 保留其余原生瞄准逻辑，不修改共享的三角函数。
- 继续使用 BotAI 现有的补丁机制，包括原始字节校验和卸载恢复。
- 将 BotAI 模块版本升级至 `1.8.7`。

## 修改原因

`CCSBot::Upkeep` 每个 tick 都会把 BotCOS 和 BotSIN 的计算结果累加到 BOT 的视角偏移中。即使目标选择本身十分稳定，这些偏移仍会造成肉眼可见的视角漂移和枪管晃动。在POV上体现为BOT在空闲时视角轻微晃动。

原版 CSGOBetterBots 通过让 BotCOS 和 BotSIN 直接返回 `0` 来消除漂移。本 PR 采用了作用范围更小的实现：只将 `CCSBot::Upkeep` 内的两处调用替换为 `xorps xmm0, xmm0`，不会影响这些三角函数在其他位置的正常使用。

## 验证结果

- 已使用当前 Windows 版 `server.dll` 完成验证：
- BotCOS 和 BotSIN 的签名均且仅匹配一次。
- 已确认打补丁前的原始调用字节：
  - BotCOS：`E8 5C 96 03 00`
  - BotSIN：`E8 6F 96 03 00`
- 已通过以下构建命令：
  - `dotnet build addons/counterstrikesharp/plugins/BotAI/BotAI.csproj`
  - 构建结果：0 个警告，0 个错误。

## 平台范围

目前仅支持 Windows。
因为没找Linux的签名。