### PR TITLE
docs: revamp README and add Chinese and Russian translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,256 +1,261 @@
+<div align="center">
+
 # CS2-Bot-Improver
-CS2-Bot-Improver is a plugin for Counter-Strike 2 that improves bots' aim, movement, nade throwing, personalities, strategies, etc.
 
-Aims to enhance your experience when playing against bots offline or with friends. It can be installed on both clients and servers.
+**Smarter, more human-like bots for Counter-Strike 2**
 
-## Your stars⭐ are my motivation to keep updating
+[![Latest release](https://img.shields.io/github/v/release/ed0ard/CS2-Bot-Improver?display_name=tag&sort=semver)](https://github.com/ed0ard/CS2-Bot-Improver/releases/latest)
+[![Release downloads](https://img.shields.io/github/downloads/ed0ard/CS2-Bot-Improver/total)](https://github.com/ed0ard/CS2-Bot-Improver/releases)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
+![Platforms: Windows and Linux](https://img.shields.io/badge/platform-Windows%20%7C%20Linux-5c6bc0)
+
+**English** · [简体中文](docs/README.zh-CN.md) · [Русский](docs/README.ru.md)
+
+[Features](#features) · [Installation](#installation) · [Commands](#commands) · [Panel guide](#panel-guide-windows-only) · [FAQ](#faq)
+
+</div>
+
+CS2 Bot Improver enhances Counter-Strike 2 bots for offline matches and private games with friends. It improves their aim, movement, grenade usage, economy, decision-making, and personality, and can be installed on either a client or a dedicated server.
+
+> ⭐ If you enjoy the project, consider [giving it a star](https://github.com/ed0ard/CS2-Bot-Improver). Your support helps keep development moving.
 
 ## Features
 
-1. Makes bots aim better and more human-like
-2. Allows bots to throw nades deftly according to the situation
-3. Improves bots' movement
-4. Fixes most bot stuck issues
-5. Allows bots to buy everything and overhauls their economy management
-6. Refines bot behavior, allowing them to spray, flick, spam smokes and anti-flash
-7. Assigns each bot their own knife, gloves, weapon skins, stickers, charms, agent model, music kit, avatar, and profile
-8. Makes bots smarter, more organized, and more alert to their surroundings
-9. Changes bot names to pro and random players. (the characteristics of each pro player are based on stats from [HLTV](https://www.hltv.org/))
-10. Removes the prefix from bot names
-11. Tweaks game rules to make them more friendly to bots
-12. Adds some commands to make the game more fun
+| Area | Improvements |
+| --- | --- |
+| **Aim and combat** | More accurate, human-like aim; spraying, flicking, smoke spamming, and anti-flash behavior |
+| **Grenades** | Situational smoke, flashbang, HE grenade, and Molotov usage |
+| **Movement** | Better movement and fixes for most common bot-stuck situations |
+| **Strategy** | Smarter, more organized bots with improved awareness and decision-making |
+| **Economy** | Expanded weapon purchases and overhauled economy management |
+| **Personalities** | Pro and random player names, with pro characteristics based on [HLTV](https://www.hltv.org/) statistics |
+| **Customization** | Per-bot knives, gloves, weapon skins, stickers, charms, agents, music kits, avatars, and profiles |
+| **Game experience** | Cleaner bot names, bot-friendly rules, and extra console commands |
 
 ## Installation
 
+Download the package for your operating system from the [latest release](https://github.com/ed0ard/CS2-Bot-Improver/releases/latest).
+
+> [!NOTE]
+> Running a dedicated server that also hosts non-bot matches? On Windows, use `CS2BotImprover_rules_unchanged.zip` to preserve the standard game rules.
+
 ### Windows
 
-1. Download the latest **CS2BotImprover.zip** in [Releases](https://github.com/ed0ard/CS2-Bot-Improver/releases) and unzip it
+1. Download and extract `CS2BotImprover.zip`.
+2. Move `Panel v1.4.3.exe` somewhere convenient.
 
-   (If you run a dedicated server that is not only for bot matches, please download **CS2BotImprover_rules_unchanged.zip**)
+   <img width="128" height="128" alt="CS2 Bot Improver Panel application icon" src="https://github.com/user-attachments/assets/7271dc7d-2436-484b-8359-6531f4abd710" />
 
-2. Put **Panel v1.4.3.exe** anywhere convenient
+3. Open your CS2 installation folder and navigate to `game/csgo`.
 
-<img width="128" height="128" alt="App" src="https://github.com/user-attachments/assets/7271dc7d-2436-484b-8359-6531f4abd710" />
+   <img width="405" height="256" alt="The game/csgo directory inside a CS2 installation" src="https://github.com/user-attachments/assets/ae2be90e-6742-4f1f-8e0c-096b728d5dbd" />
 
-3. Open the root of CS2 and navigate to `game/csgo` directory
+4. Copy all remaining files from the extracted package folder into `game/csgo`.
 
-<img width="405" height="256" alt="snap_1" src="https://github.com/user-attachments/assets/ae2be90e-6742-4f1f-8e0c-096b728d5dbd" />
+   <img width="540" height="181" alt="Copying the Windows package files into game/csgo" src="https://github.com/user-attachments/assets/6a8645fc-78e7-4f3a-92d3-5d1b6d913918" />
 
-3. Copy all the remaining files in `CS2BotImprover` and paste them into `game/csgo`
+5. Open `Panel v1.4.3.exe`, select **Bot Mode**, and click **Launch CS2**.
 
-<img width="540" height="181" alt="snap_windows" src="https://github.com/user-attachments/assets/6a8645fc-78e7-4f3a-92d3-5d1b6d913918" />
-
-4. Open **Panel v1.4.3.exe**, select **Bot Mode**, then click **Launch CS2** 
-
-<img width="339" height="129" alt="Panel_1" src="https://github.com/user-attachments/assets/dc806991-c940-43cf-a614-f49012fae4a7" />
-
+   <img width="339" height="129" alt="Selecting Bot Mode and launching CS2 from the Panel" src="https://github.com/user-attachments/assets/dc806991-c940-43cf-a614-f49012fae4a7" />
 
 ### Linux
 
-1. Download the latest **CS2BotImprover_for_Linux.zip** in [Releases](https://github.com/ed0ard/CS2-Bot-Improver/releases) and unzip it
+1. Download and extract `CS2BotImprover_for_Linux.zip`.
+2. Move `Commands.txt` somewhere convenient for quick access.
+3. Open your CS2 installation folder and navigate to `game/csgo`.
 
-2. Put **Command.txt** anywhere convenient
+   <img width="405" height="256" alt="The game/csgo directory inside a CS2 installation" src="https://github.com/user-attachments/assets/ae2be90e-6742-4f1f-8e0c-096b728d5dbd" />
 
-3. Open the root of CS2 and navigate to `game/csgo` directory
+4. Copy all remaining files from the extracted package folder into `game/csgo`.
 
-<img width="405" height="256" alt="snap_1" src="https://github.com/user-attachments/assets/ae2be90e-6742-4f1f-8e0c-096b728d5dbd" />
+   <img width="535" height="180" alt="Copying the Linux package files into game/csgo" src="https://github.com/user-attachments/assets/9bda7b1d-43d3-49cf-a283-27b124b894e0" />
 
-4. Copy all the remaining files in `CS2BotImprover` and paste them into `game/csgo`
+5. Add `-insecure` to your CS2 launch options.
 
-<img width="535" height="180" alt="snap_linux" src="https://github.com/user-attachments/assets/9bda7b1d-43d3-49cf-a283-27b124b894e0" />
-
-5. Add `-insecure` in launch options
-
-<img width="130" height="153" alt="snap_3" src="https://github.com/user-attachments/assets/4c775e36-3fc3-4a19-9cb1-4f0c9327838c" /><br>
-<img width="625" height="423" alt="snap_4" src="https://github.com/user-attachments/assets/ac0b0c57-ee67-4e33-96fb-146d14714fc8" />
+   <img width="130" height="153" alt="Opening CS2 properties in Steam" src="https://github.com/user-attachments/assets/4c775e36-3fc3-4a19-9cb1-4f0c9327838c" /><br>
+   <img width="625" height="423" alt="Adding -insecure to the CS2 launch options" src="https://github.com/user-attachments/assets/ac0b0c57-ee67-4e33-96fb-146d14714fc8" />
 
 ## Commands
 
 ### Aim
 
-`bot_aim mixed`  
-Bots select aiming spots flexibly based on situations (default)
+| Command | Description |
+| --- | --- |
+| `bot_aim mixed` | Select aiming spots dynamically based on the situation. **Default.** |
+| `bot_aim head` | Prioritize aiming at the head. |
+| `bot_aim body` | Prioritize aiming at the torso. |
+| `bot_aim` | Show the current aim mode. |
 
-`bot_aim head`  
-Bots prioritize aiming at the head
+### Grenades
 
-`bot_aim body`  
-Bots prioritize aiming at the torso
-
-`bot_aim`  
-Check the current aim mode
-
-### Nades
-
-`bot_nades off`  
-Bots won't throw any nades
-
-`bot_nades less`  
-Bots use the same decision logic as normal mode with lower count limits
-
-`bot_nades normal`  
-Bots follow almost the same count limits as human players (default)
-
-`bot_nades more`  
-Bots use the same decision logic as normal mode with higher count limits
-
-`bot_nades max`  
-Bots have minimal limitations and think less before throwing nades
-
-`bot_nades`  
-Shows the current nade throwing mode
+| Command | Description |
+| --- | --- |
+| `bot_nades off` | Disable bot grenade usage. |
+| `bot_nades less` | Use the normal decision logic with lower grenade-count limits. |
+| `bot_nades normal` | Use limits close to those of human players. **Default.** |
+| `bot_nades more` | Use the normal decision logic with higher grenade-count limits. |
+| `bot_nades max` | Apply minimal limits and reduce the time bots spend deciding whether to throw. |
+| `bot_nades` | Show the current grenade mode. |
 
 ### Skins
 
-`br_reroll`  
-Reroll all bot skins on their next spawn
+| Command | Description |
+| --- | --- |
+| `br_reroll` | Reroll every bot's cosmetics on its next spawn. |
 
-### Buy
+### Buying
 
-Input the weapon's name in your console to give every bot this weapon from the next round
+Enter a weapon name in the game console to give every bot that weapon starting with the next round. Enter `bot_buy` to restore normal buying behavior.
 
-The valid names of weapons:  
-`elite`  
-`p250`  
-`fn57`  
-`deagle`  
-`cz75a`  
-`r8`  
-`bizon`  
-`p90`  
-`mp5sd`  
-`mp9`  
-`mp7`  
-`mac10`  
-`ump45`  
-`mag7`  
-`sawedoff`  
-`nova`  
-`xm1014`  
-`famas`  
-`galilar`  
-`m4a1`  
-`m4a1s`  
-`ak47`  
-`aug`  
-`sg556`  
-`ssg08`  
-`awp`  
-`scar20`  
-`g3sg1`  
-`negev`  
-`m249`
+<details>
+<summary><strong>Show supported weapon names</strong></summary>
 
-`bot_buy`  
-Bot would buy as usual
+```text
+elite     p250      fn57      deagle    cz75a     r8
+bizon     p90       mp5sd     mp9       mp7       mac10     ump45
+mag7      sawedoff  nova      xm1014
+famas     galilar   m4a1      m4a1s     ak47      aug       sg556
+ssg08     awp       scar20    g3sg1
+negev     m249
+```
 
-### Teams
+</details>
 
-To add pro teams to your match, copy from [Commands.txt](https://github.com/ed0ard/CS2-Bot-Improver/blob/main/Commands.txt) and paste them to your game console. You can also add new teams in this format.
+### Pro teams
 
-For example, if you wanna add Vit to CT, copy the commands below.
+Copy a team command from [Commands.txt](Commands.txt) and paste it into the game console. You can add your own teams using the same format.
 
-<img width="301" height="237" alt="snap_5" src="https://github.com/user-attachments/assets/a895f3a6-58f8-47dc-b6f5-b60c1b32fecd" />
+For example, the following block in `Commands.txt` adds Team Vitality to the CT side:
+
+<img width="301" height="237" alt="Team Vitality commands in Commands.txt" src="https://github.com/user-attachments/assets/a895f3a6-58f8-47dc-b6f5-b60c1b32fecd" />
 
 ### Knives
 
-Point at the ground and press `\` on your keyboard to generate all kinds of knives there.
+Point at the ground and press <kbd>\</kbd> to spawn the available knives at that location.
 
 ### Flying Scoutsman
 
-`scouts_on`  
-`scouts_off`  
-Input the command after a match begins to turn on/off Flying Scoutsman
+After a match begins, use `scouts_on` or `scouts_off` to enable or disable Flying Scoutsman mode.
 
-## Panel Guide (Windows-Only)
+## Panel Guide (Windows Only)
 
-### Status Lights
-🟢 No issues detected  
-🟡 Restart CS2 to apply changes  
-🔴 Files missing. Click the red light to view the list of missing files  
+### Status lights
 
-<img width="481" height="82" alt="Status Lights" src="https://github.com/user-attachments/assets/26a947e2-4e0e-423f-bce8-f220d88509a2" />
+| Indicator | Meaning |
+| --- | --- |
+| 🟢 Green | No issues detected. |
+| 🟡 Yellow | Restart CS2 to apply the changes. |
+| 🔴 Red | Files are missing. Click the red indicator to see which files are missing. |
 
-### Matchmaking & Bot Mode Toggle
-Select your desired mode, then click `Launch CS2`
+<img width="481" height="82" alt="Green, yellow, and red Panel status indicators" src="https://github.com/user-attachments/assets/26a947e2-4e0e-423f-bce8-f220d88509a2" />
 
-<img width="472" height="179" alt="Mode_2" src="https://github.com/user-attachments/assets/3f9254fa-4cbe-4854-8fd1-0f35228fff77" />
+### Online Mode and Bot Mode
+
+Select the mode you want, then click **Launch CS2**.
+
+<img width="472" height="179" alt="Online Mode and Bot Mode selector in the Panel" src="https://github.com/user-attachments/assets/3f9254fa-4cbe-4854-8fd1-0f35228fff77" />
 
 ### Settings
-Click the <img width="31" height="32" alt="Settings" src="https://github.com/user-attachments/assets/7f94176b-79f1-4e22-9495-4589c4dea9eb" /> icon in the top-right corner to open `Settings`
 
-### Commands
-Click `Commands`, click a block to auto-copy, or type keywords to search
+Click the <img width="31" height="32" alt="Settings" src="https://github.com/user-attachments/assets/7f94176b-79f1-4e22-9495-4589c4dea9eb" /> icon in the top-right corner to open **Settings**.
 
-<img width="350" height="420" alt="Screenshot 2026-06-14 090901" src="https://github.com/user-attachments/assets/957cfafb-900d-4450-b985-13d3e8efc375" />
+### Command browser
+
+Open **Commands**, click a block to copy it automatically, or type a keyword to search.
+
+<img width="350" height="420" alt="Searchable command browser in the Panel" src="https://github.com/user-attachments/assets/957cfafb-900d-4450-b985-13d3e8efc375" />
 
 ## FAQ
 
-### How to play bot matches with friends
+<details>
+<summary><strong>How do I play bot matches with friends?</strong></summary>
 
-1. Start a bot match and input the required commands. Then type `status` in the console  
-<img width="597" height="141" alt="snap_6" src="https://github.com/user-attachments/assets/792c4b4f-1d56-4a39-9186-b301cbff1846" />
+1. Start a bot match, enter any required commands, and then run `status` in the console.
 
-2. Copy the text after `steamid:`, add `connect ` before it (don’t forget the space between them)  
-3. Send the full command to your friends and have them paste it into their consoles
+   <img width="597" height="141" alt="The steamid value shown by the status command" src="https://github.com/user-attachments/assets/792c4b4f-1d56-4a39-9186-b301cbff1846" />
 
-### How to manually change the difficulty level
+2. Copy the text after `steamid:` and add `connect ` before it, including the space.
+3. Send the complete command to your friends and have them paste it into their consoles.
 
-1. Open the root of CS2 and navigate to `game/csgo/overrides` directory  
-2. Open the `Low` for easy difficulty, `Medium` for a mixed difficulty based on HLTV stats (default), and `High` for extreme difficulty  
-3. Copy `botprofile.vpk` and paste it into `game/csgo/overrides` before launching the game
+</details>
 
-### How to manually switch to normal online match mode
+<details>
+<summary><strong>How do I manually change the difficulty?</strong></summary>
 
-1. Open the root of CS2 and navigate to `game/csgo/backup/Online` directory  
-2. Copy `gameinfo.gi` and paste it to `game/csgo` directory (Replace the file in the destination)  
-3. Delete `-insecure` in your launch options  
+1. Navigate to `game/csgo/overrides` in your CS2 installation.
+2. Open `Low` for easy difficulty, `Medium` for mixed difficulty based on HLTV statistics (**default**), or `High` for extreme difficulty.
+3. Before launching the game, copy the selected `botprofile.vpk` into `game/csgo/overrides`.
 
-After modification, if you wanna **play with bots again**, navigate to `game/csgo/backup/WithBots` directory, replace the file as above and add the launch option
+</details>
 
-### How to manually disable bot weapon skins, agent skins, music kits, knives and gloves
+<details>
+<summary><strong>How do I manually switch back to normal online matchmaking?</strong></summary>
 
-1. Open the root of CS2 and navigate to `game/csgo/addons/counterstrikesharp/plugins`  
-2. Rename the `BotRandomizer` folder to `BotRandomizer_disabled`  
-3. Navigate to `addons/counterstrikesharp/configs/core.json` and set `FollowCS2ServerGuidelines` to `true`
+1. Navigate to `game/csgo/backup/Online` in your CS2 installation.
+2. Copy `gameinfo.gi` into `game/csgo` and replace the destination file.
+3. Remove `-insecure` from your launch options.
 
-### How to manually disable bot steam profiles
+To play with bots again, copy `gameinfo.gi` from `game/csgo/backup/WithBots` into `game/csgo`, replace the destination file, and restore the launch option.
 
-1. Open the root of CS2 and navigate to `game/csgo/addons`  
-2. Rename the `BotHider` folder to `BotHider_disabled`  
+</details>
 
-### How to run the plugin well on workshop maps
+<details>
+<summary><strong>How do I disable bot weapon skins, agents, music kits, knives, and gloves?</strong></summary>
 
-Add `-disable_workshop_command_filtering` to your launch options
+1. Navigate to `game/csgo/addons/counterstrikesharp/plugins`.
+2. Rename `BotRandomizer` to `BotRandomizer_disabled`.
+3. Open `addons/counterstrikesharp/configs/core.json` and set `FollowCS2ServerGuidelines` to `true`.
 
-### How to surf normally
+</details>
 
-Run `sv_standable_normal 0.7` in your game console
+<details>
+<summary><strong>How do I disable bot Steam profiles?</strong></summary>
 
-### Will I get VAC banned for using this plugin
+Navigate to `game/csgo/addons` and rename `BotHider` to `BotHider_disabled`.
 
-This plugin itself poses no VAC ban risk.
+</details>
 
-However, if you use other third-party player skin-changing features alongside it, there may be a ban risk. Please use at your own risk.
+<details>
+<summary><strong>How do I use the plugin on Workshop maps?</strong></summary>
+
+Add `-disable_workshop_command_filtering` to your launch options.
+
+</details>
+
+<details>
+<summary><strong>How do I surf normally?</strong></summary>
+
+Run `sv_standable_normal 0.7` in the game console.
+
+</details>
+
+### Where can I safely use this plugin?
+
+> [!WARNING]
+> This project is intended for offline bot matches, self-hosted private games with friends, and private dedicated servers. Its automatic cosmetic-assignment path targets bots and is not intended to alter human-player inventories or cosmetics, consistent with [Valve's CS2 GSLT rules](https://help.steampowered.com/en/faqs/view/07AF-502E-A104-BD4B).
+>
+> Do not use the project in Valve official matchmaking, on VAC-secured public servers, on [FACEIT](https://support.faceit.com/hc/en-us/articles/360015788779-What-is-deemed-to-be-a-cheat), on third-party public community servers, or to bypass any anti-cheat or security control. Before entering those services, switch the Panel to **Online Mode** or manually restore the normal game files, remove `-insecure`, and restart CS2. Rights granted by the [AGPL-3.0 license](LICENSE) do not authorize violations of platform or server rules. To the maximum extent permitted by applicable law, users assume responsibility for out-of-scope use and any resulting GSLT, server, FACEIT, VAC, game, or account sanctions. This notice is informational and is not legal advice.
 
 ## Credits
-[metamod-source](https://github.com/alliedmodders/metamod-source)  
-[CounterStrikeSharp](https://github.com/roflmuffin/CounterStrikeSharp)  
-[Ray-Trace](https://github.com/FUNPLAY-pro-CS2/Ray-Trace)  
-[CS2-Bullseye-Bot](https://github.com/ed0ard/CS2-Bullseye-Bot)  
-[CS2-Bot-NadeSystem](https://github.com/ed0ard/CS2-Bot-NadeSystem)  
-[CS2_ExecAfter_No_Admin](https://github.com/ed0ard/CS2_ExecAfter_No_Admin) forked from [kus](https://github.com/kus)  
-[CS2-Bot-Randomizer](https://github.com/ed0ard/CS2-Bot-Randomizer)  
-[CS2-Lib](https://github.com/ianlucas/cs2-lib) by [Lucas](https://github.com/ianlucas)  
-[CS2-Bot-Hider](https://github.com/XBribo/CS2-Bot-Hider) by [XBribo](https://github.com/XBribo)  
-[CS2-Bot-Controller](https://github.com/XBribo/CS2-Bot-Controller) by [XBribo](https://github.com/XBribo)  
-[CSGOBetterBots](https://github.com/manicogaming/CSGOBetterBots/blob/master/addons/sourcemod/data/bot_info.json) by [manico](https://github.com/manicogaming)  
-[CS2-Smarter-Bot](https://github.com/ed0ard/CS2-Smarter-Bot)  
-[CS2-BotAI](https://github.com/ed0ard/CS2-BotAI) forked from [Austin](https://github.com/Austinbots)  
-[CS2-BotAI-for-Linux](https://github.com/Austinbots/CS2-BotAI)  
-[CS2-Bot-Buy](https://github.com/ed0ard/CS2-Bot-Buy)  
-[RoundDamageRecap](https://github.com/YuGeYu/LBTV-CS2-Bot-Enhancer/tree/main/addons/counterstrikesharp/plugins/RoundDamageRecap) by [YuGeYu](https://github.com/YuGeYu)  
-[Apple-Style-GUI](https://github.com/ed0ard/Apple-Style-GUI)  
+
+- [Metamod:Source](https://github.com/alliedmodders/metamod-source)
+- [CounterStrikeSharp](https://github.com/roflmuffin/CounterStrikeSharp)
+- [Ray-Trace](https://github.com/FUNPLAY-pro-CS2/Ray-Trace)
+- [CS2-Bullseye-Bot](https://github.com/ed0ard/CS2-Bullseye-Bot)
+- [CS2-Bot-NadeSystem](https://github.com/ed0ard/CS2-Bot-NadeSystem)
+- [CS2_ExecAfter_No_Admin](https://github.com/ed0ard/CS2_ExecAfter_No_Admin), forked from [kus](https://github.com/kus)
+- [CS2-Bot-Randomizer](https://github.com/ed0ard/CS2-Bot-Randomizer)
+- [CS2-Lib](https://github.com/ianlucas/cs2-lib) by [Lucas](https://github.com/ianlucas)
+- [CS2-Bot-Hider](https://github.com/XBribo/CS2-Bot-Hider) by [XBribo](https://github.com/XBribo)
+- [CS2-Bot-Controller](https://github.com/XBribo/CS2-Bot-Controller) by [XBribo](https://github.com/XBribo)
+- [CSGOBetterBots](https://github.com/manicogaming/CSGOBetterBots/blob/master/addons/sourcemod/data/bot_info.json) by [manico](https://github.com/manicogaming)
+- [CS2-Smarter-Bot](https://github.com/ed0ard/CS2-Smarter-Bot)
+- [CS2-BotAI](https://github.com/ed0ard/CS2-BotAI), forked from [Austin](https://github.com/Austinbots)
+- [CS2-BotAI-for-Linux](https://github.com/Austinbots/CS2-BotAI)
+- [CS2-Bot-Buy](https://github.com/ed0ard/CS2-Bot-Buy)
+- [RoundDamageRecap](https://github.com/YuGeYu/LBTV-CS2-Bot-Enhancer/tree/main/addons/counterstrikesharp/plugins/RoundDamageRecap) by [YuGeYu](https://github.com/YuGeYu)
+- [Apple-Style-GUI](https://github.com/ed0ard/Apple-Style-GUI)
 
 ## License
-AGPL-3.0
+
+CS2 Bot Improver is licensed under the [GNU Affero General Public License v3.0](LICENSE).

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -1,0 +1,286 @@
+<div align="center">
+
+# CS2-Bot-Improver
+
+**Более умные и естественные боты для Counter-Strike 2**
+
+[![Последний выпуск](https://img.shields.io/github/v/release/ed0ard/CS2-Bot-Improver?display_name=tag&sort=semver)](https://github.com/ed0ard/CS2-Bot-Improver/releases/latest)
+[![Всего загрузок](https://img.shields.io/github/downloads/ed0ard/CS2-Bot-Improver/total)](https://github.com/ed0ard/CS2-Bot-Improver/releases)
+[![Лицензия: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](../LICENSE)
+![Платформы: Windows и Linux](https://img.shields.io/badge/platform-Windows%20%7C%20Linux-5c6bc0)
+
+[English](../README.md) · [简体中文](README.zh-CN.md) · **Русский**
+
+[Возможности](#возможности) · [Установка](#установка) · [Команды](#команды) · [Panel](#руководство-по-panel-только-для-windows) · [FAQ](#часто-задаваемые-вопросы)
+
+</div>
+
+> Плагин для Counter-Strike 2, который улучшает прицеливание и перемещение ботов, использование гранат, индивидуальные особенности, стратегии и многое другое.
+
+Он делает интереснее офлайн-матчи с ботами и частные игры с друзьями, размещённые самим пользователем. Плагин можно установить как на игровой клиент, так и на выделенный сервер.
+
+> ⭐ Ваши звёзды мотивируют автора продолжать обновлять проект.
+
+## Содержание
+
+- [Возможности](#возможности)
+- [Установка](#установка)
+  - [Windows](#windows)
+  - [Linux](#linux)
+- [Команды](#команды)
+- [Руководство по Panel](#руководство-по-panel-только-для-windows)
+- [Часто задаваемые вопросы](#часто-задаваемые-вопросы)
+- [Благодарности](#благодарности)
+- [Лицензия](#лицензия)
+
+## Возможности
+
+1. Улучшает прицеливание ботов, сохраняя естественное, похожее на человеческое поведение.
+2. Позволяет ботам умело использовать гранаты в зависимости от ситуации.
+3. Улучшает перемещение ботов.
+4. Исправляет большинство случаев, когда боты застревают.
+5. Позволяет ботам покупать всё доступное снаряжение и полностью перерабатывает управление их экономикой.
+6. Улучшает поведение ботов: они могут зажимать очередь, резко переводить прицел, простреливать дым и отворачиваться от светошумовых гранат.
+7. Назначает каждому боту собственные нож, перчатки, скины оружия, наклейки, брелоки, модель агента, музыкальный набор, аватар и профиль.
+8. Делает ботов умнее, организованнее и внимательнее к окружению.
+9. Заменяет имена ботов именами профессиональных и случайных игроков. Характеристики каждого профессионального игрока основаны на статистике [HLTV](https://www.hltv.org/).
+10. Убирает префикс из имён ботов.
+11. Настраивает правила игры так, чтобы они лучше подходили для ботов.
+12. Добавляет команды, которые делают игру разнообразнее.
+
+## Установка
+
+### Windows
+
+1. Скачайте архив **CS2BotImprover.zip** со страницы [последнего выпуска](https://github.com/ed0ard/CS2-Bot-Improver/releases/latest) и распакуйте его.
+
+   Если выделенный сервер используется не только для матчей с ботами, скачайте **CS2BotImprover_rules_unchanged.zip**.
+
+2. Поместите **Panel v1.4.3.exe** в любое удобное место.
+
+   <img width="128" height="128" alt="Приложение Panel" src="https://github.com/user-attachments/assets/7271dc7d-2436-484b-8359-6531f4abd710" />
+
+3. Откройте корневую папку CS2 и перейдите в каталог `game/csgo`.
+
+   <img width="405" height="256" alt="Переход в каталог game/csgo" src="https://github.com/user-attachments/assets/ae2be90e-6742-4f1f-8e0c-096b728d5dbd" />
+
+4. Скопируйте все остальные файлы из распакованного архива в `game/csgo`.
+
+   <img width="540" height="181" alt="Копирование файлов в Windows" src="https://github.com/user-attachments/assets/6a8645fc-78e7-4f3a-92d3-5d1b6d913918" />
+
+5. Откройте **Panel v1.4.3.exe**, выберите **Bot Mode**, затем нажмите **Launch CS2**.
+
+   <img width="339" height="129" alt="Запуск CS2 в Bot Mode" src="https://github.com/user-attachments/assets/dc806991-c940-43cf-a614-f49012fae4a7" />
+
+### Linux
+
+1. Скачайте архив **CS2BotImprover_for_Linux.zip** со страницы [последнего выпуска](https://github.com/ed0ard/CS2-Bot-Improver/releases/latest) и распакуйте его.
+2. Поместите **Commands.txt** в любое удобное место.
+3. Откройте корневую папку CS2 и перейдите в каталог `game/csgo`.
+
+   <img width="405" height="256" alt="Переход в каталог game/csgo" src="https://github.com/user-attachments/assets/ae2be90e-6742-4f1f-8e0c-096b728d5dbd" />
+
+4. Скопируйте все остальные файлы из распакованного архива в `game/csgo`.
+
+   <img width="535" height="180" alt="Копирование файлов в Linux" src="https://github.com/user-attachments/assets/9bda7b1d-43d3-49cf-a283-27b124b894e0" />
+
+5. Добавьте `-insecure` в параметры запуска.
+
+   <img width="130" height="153" alt="Открытие параметров запуска" src="https://github.com/user-attachments/assets/4c775e36-3fc3-4a19-9cb1-4f0c9327838c" /><br>
+   <img width="625" height="423" alt="Добавление параметра -insecure" src="https://github.com/user-attachments/assets/ac0b0c57-ee67-4e33-96fb-146d14714fc8" />
+
+## Команды
+
+### Прицеливание
+
+| Команда | Описание |
+| --- | --- |
+| `bot_aim mixed` | Боты гибко выбирают точку прицеливания в зависимости от ситуации. Режим по умолчанию. |
+| `bot_aim head` | Боты в первую очередь целятся в голову. |
+| `bot_aim body` | Боты в первую очередь целятся в корпус. |
+| `bot_aim` | Показывает текущий режим прицеливания. |
+
+### Гранаты
+
+| Команда | Описание |
+| --- | --- |
+| `bot_nades off` | Боты не используют гранаты. |
+| `bot_nades less` | Боты используют ту же логику принятия решений, что и в обычном режиме, но с более низкими ограничениями по количеству. |
+| `bot_nades normal` | Ограничения по количеству гранат почти такие же, как у игроков. Режим по умолчанию. |
+| `bot_nades more` | Боты используют ту же логику принятия решений, что и в обычном режиме, но с более высокими ограничениями по количеству. |
+| `bot_nades max` | Ограничения минимальны, а перед броском гранаты боты раздумывают меньше. |
+| `bot_nades` | Показывает текущий режим использования гранат. |
+
+### Скины
+
+| Команда | Описание |
+| --- | --- |
+| `br_reroll` | При следующем появлении заново выбирает скины для всех ботов. |
+
+### Покупка оружия
+
+Введите имя оружия в игровой консоли, чтобы со следующего раунда выдать это оружие каждому боту.
+
+<details>
+<summary><strong>Допустимые имена оружия</strong></summary>
+
+```text
+elite
+p250
+fn57
+deagle
+cz75a
+r8
+bizon
+p90
+mp5sd
+mp9
+mp7
+mac10
+ump45
+mag7
+sawedoff
+nova
+xm1014
+famas
+galilar
+m4a1
+m4a1s
+ak47
+aug
+sg556
+ssg08
+awp
+scar20
+g3sg1
+negev
+m249
+```
+
+</details>
+
+`bot_buy` — боты снова будут покупать оружие как обычно.
+
+### Профессиональные команды
+
+Чтобы добавить в матч профессиональные команды, скопируйте нужный набор из [Commands.txt](../Commands.txt) и вставьте его в игровую консоль. В том же формате можно добавлять новые команды.
+
+Например, чтобы добавить Vit за сторону CT, скопируйте команды, показанные ниже.
+
+<img width="301" height="237" alt="Добавление Vit за сторону CT" src="https://github.com/user-attachments/assets/a895f3a6-58f8-47dc-b6f5-b60c1b32fecd" />
+
+### Ножи
+
+Наведите прицел на землю и нажмите клавишу `\`, чтобы создать там все виды ножей.
+
+### «Перелётные снайперы» (Flying Scoutsman)
+
+| Команда | Действие |
+| --- | --- |
+| `scouts_on` | Включить режим Flying Scoutsman. |
+| `scouts_off` | Выключить режим Flying Scoutsman. |
+
+Введите нужную команду после начала матча.
+
+## Руководство по Panel (только для Windows)
+
+### Индикаторы состояния
+
+| Индикатор | Значение |
+| --- | --- |
+| 🟢 | Проблем не обнаружено. |
+| 🟡 | Перезапустите CS2, чтобы применить изменения. |
+| 🔴 | Отсутствуют файлы. Нажмите на красный индикатор, чтобы посмотреть их список. |
+
+<img width="481" height="82" alt="Индикаторы состояния" src="https://github.com/user-attachments/assets/26a947e2-4e0e-423f-bce8-f220d88509a2" />
+
+### Онлайн-режим и режим ботов
+
+Выберите нужный режим, затем нажмите `Launch CS2`.
+
+<img width="472" height="179" alt="Переключение режима" src="https://github.com/user-attachments/assets/3f9254fa-4cbe-4854-8fd1-0f35228fff77" />
+
+### Настройки
+
+Нажмите значок <img width="31" height="32" alt="Настройки" src="https://github.com/user-attachments/assets/7f94176b-79f1-4e22-9495-4589c4dea9eb" /> в правом верхнем углу, чтобы открыть `Settings`.
+
+### Команды
+
+Откройте `Commands`: нажмите на блок, чтобы автоматически скопировать его содержимое, или введите ключевые слова для поиска.
+
+<img width="350" height="420" alt="Раздел Commands" src="https://github.com/user-attachments/assets/957cfafb-900d-4450-b985-13d3e8efc375" />
+
+## Часто задаваемые вопросы
+
+### Как играть матчи с ботами вместе с друзьями?
+
+1. Запустите матч с ботами и введите необходимые команды. Затем введите `status` в консоли.
+
+   <img width="597" height="141" alt="Вывод команды status" src="https://github.com/user-attachments/assets/792c4b4f-1d56-4a39-9186-b301cbff1846" />
+
+2. Скопируйте текст после `steamid:` и добавьте перед ним `connect ` — не забудьте пробел.
+3. Отправьте полную команду друзьям, чтобы они вставили её в свои консоли.
+
+### Как вручную изменить уровень сложности?
+
+1. Откройте корневую папку CS2 и перейдите в каталог `game/csgo/overrides`.
+2. Откройте папку `Low` для лёгкого уровня сложности, `Medium` для смешанной сложности на основе статистики HLTV (по умолчанию) или `High` для экстремальной сложности.
+3. Скопируйте `botprofile.vpk` в `game/csgo/overrides` до запуска игры.
+
+### Как вручную переключиться в режим обычного сетевого матча?
+
+1. Откройте корневую папку CS2 и перейдите в каталог `game/csgo/backup/Online`.
+2. Скопируйте `gameinfo.gi` в каталог `game/csgo`, заменив файл в папке назначения.
+3. Удалите `-insecure` из параметров запуска.
+
+Чтобы после этого **снова играть с ботами**, перейдите в каталог `game/csgo/backup/WithBots`, замените файл описанным выше способом и снова добавьте параметр запуска.
+
+### Как вручную отключить скины оружия и агентов, музыкальные наборы, ножи и перчатки ботов?
+
+1. Откройте корневую папку CS2 и перейдите в каталог `game/csgo/addons/counterstrikesharp/plugins`.
+2. Переименуйте папку `BotRandomizer` в `BotRandomizer_disabled`.
+3. Откройте `addons/counterstrikesharp/configs/core.json` и задайте параметру `FollowCS2ServerGuidelines` значение `true`.
+
+### Как вручную отключить Steam-профили ботов?
+
+1. Откройте корневую папку CS2 и перейдите в каталог `game/csgo/addons`.
+2. Переименуйте папку `BotHider` в `BotHider_disabled`.
+
+### Как правильно запустить плагин на картах из Мастерской?
+
+Добавьте `-disable_workshop_command_filtering` в параметры запуска.
+
+### Как нормально играть на surf-картах?
+
+Выполните `sv_standable_normal 0.7` в игровой консоли.
+
+### Где можно безопасно использовать проект?
+
+> [!WARNING]
+> Проект предназначен для офлайн-матчей с ботами, частных игр с друзьями, размещённых самим пользователем, и частных выделенных серверов. Автоматическое назначение косметических предметов применяется только к ботам и не предназначено для изменения инвентаря или предметов реальных игроков; это ограничение соответствует [правилам Valve для CS2 и GSLT](https://help.steampowered.com/en/faqs/view/07AF-502E-A104-BD4B).
+>
+> Не используйте проект в официальном матчмейкинге Valve, на публичных серверах с защитой VAC, в [FACEIT](https://support.faceit.com/hc/en-us/articles/360015788779-What-is-deemed-to-be-a-cheat), на сторонних публичных серверах сообщества или для обхода античит-систем и средств защиты. Перед подключением к таким сервисам переключите Panel в **Онлайн-режим (Online Mode)** либо восстановите стандартные файлы игры, удалите `-insecure` и перезапустите CS2. Права по лицензии [AGPL-3.0](../LICENSE) не разрешают нарушать правила платформ или серверов. В максимальной степени, разрешённой применимым законодательством, пользователь несёт ответственность за использование вне указанной области и связанные с ним санкции в отношении GSLT, сервера, FACEIT, VAC, игры или учётной записи. Этот текст носит информационный характер и не является юридической консультацией.
+
+## Благодарности
+
+- [metamod-source](https://github.com/alliedmodders/metamod-source)
+- [CounterStrikeSharp](https://github.com/roflmuffin/CounterStrikeSharp)
+- [Ray-Trace](https://github.com/FUNPLAY-pro-CS2/Ray-Trace)
+- [CS2-Bullseye-Bot](https://github.com/ed0ard/CS2-Bullseye-Bot)
+- [CS2-Bot-NadeSystem](https://github.com/ed0ard/CS2-Bot-NadeSystem)
+- [CS2_ExecAfter_No_Admin](https://github.com/ed0ard/CS2_ExecAfter_No_Admin), форк проекта [kus](https://github.com/kus)
+- [CS2-Bot-Randomizer](https://github.com/ed0ard/CS2-Bot-Randomizer)
+- [CS2-Lib](https://github.com/ianlucas/cs2-lib) от [Lucas](https://github.com/ianlucas)
+- [CS2-Bot-Hider](https://github.com/XBribo/CS2-Bot-Hider) от [XBribo](https://github.com/XBribo)
+- [CS2-Bot-Controller](https://github.com/XBribo/CS2-Bot-Controller) от [XBribo](https://github.com/XBribo)
+- [CSGOBetterBots](https://github.com/manicogaming/CSGOBetterBots/blob/master/addons/sourcemod/data/bot_info.json) от [manico](https://github.com/manicogaming)
+- [CS2-Smarter-Bot](https://github.com/ed0ard/CS2-Smarter-Bot)
+- [CS2-BotAI](https://github.com/ed0ard/CS2-BotAI), форк проекта [Austin](https://github.com/Austinbots)
+- [CS2-BotAI-for-Linux](https://github.com/Austinbots/CS2-BotAI)
+- [CS2-Bot-Buy](https://github.com/ed0ard/CS2-Bot-Buy)
+- [RoundDamageRecap](https://github.com/YuGeYu/LBTV-CS2-Bot-Enhancer/tree/main/addons/counterstrikesharp/plugins/RoundDamageRecap) от [YuGeYu](https://github.com/YuGeYu)
+- [Apple-Style-GUI](https://github.com/ed0ard/Apple-Style-GUI)
+
+## Лицензия
+
+Проект распространяется по лицензии [GNU Affero General Public License v3.0](../LICENSE).

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,0 +1,267 @@
+<div align="center">
+
+# CS2-Bot-Improver
+
+**让《Counter-Strike 2》的机器人更聪明、更接近真人**
+
+[![最新版本](https://img.shields.io/github/v/release/ed0ard/CS2-Bot-Improver?display_name=tag&sort=semver)](https://github.com/ed0ard/CS2-Bot-Improver/releases/latest)
+[![累计下载](https://img.shields.io/github/downloads/ed0ard/CS2-Bot-Improver/total)](https://github.com/ed0ard/CS2-Bot-Improver/releases)
+[![许可证：AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](../LICENSE)
+![平台：Windows 与 Linux](https://img.shields.io/badge/platform-Windows%20%7C%20Linux-5c6bc0)
+
+[English](../README.md) · **简体中文** · [Русский](README.ru.md)
+
+[功能](#功能) · [安装](#安装) · [命令](#命令) · [Panel 指南](#panel-使用指南仅限-windows) · [常见问题](#常见问题)
+
+</div>
+
+> 一款面向《Counter-Strike 2》的机器人增强插件，改进机器人的瞄准、移动、投掷物使用、个性、战术等表现。
+
+本项目旨在改善离线机器人对局及与好友自行托管的私人对局体验，同时支持安装在游戏客户端和专用服务器上。
+
+> ⭐ 你的 Star 是作者持续更新的动力。
+
+## 功能
+
+1. 让机器人的瞄准更精准，也更接近真人表现。
+2. 让机器人能够根据战况灵活使用投掷物。
+3. 改进机器人的移动表现。
+4. 修复大多数机器人卡住的问题。
+5. 允许机器人购买所有物品，并全面改进其经济管理。
+6. 优化机器人行为，使其能够扫射、甩枪、混烟和背闪。
+7. 为每个机器人分配独立的刀具、手套、武器皮肤、印花、挂件、探员模型、音乐盒、头像和个人资料。
+8. 让机器人更聪明、更有组织性，也更警觉周围环境。
+9. 将机器人名称替换为职业选手或随机玩家名称；每位职业选手的特征均基于 [HLTV](https://www.hltv.org/) 数据。
+10. 移除机器人名称前缀。
+11. 调整游戏规则，使其对机器人更友好。
+12. 添加一些命令，让游戏更有趣。
+
+## 安装
+
+### Windows
+
+1. 在[最新版本](https://github.com/ed0ard/CS2-Bot-Improver/releases/latest)中下载 **CS2BotImprover.zip** 并解压。
+
+   > 如果你运行的专用服务器并非只用于机器人对局，请下载 **CS2BotImprover_rules_unchanged.zip**。
+
+2. 将 **Panel v1.4.3.exe** 放在方便使用的任意位置。
+
+   <img width="128" height="128" alt="Panel 应用" src="https://github.com/user-attachments/assets/7271dc7d-2436-484b-8359-6531f4abd710" />
+
+3. 打开 CS2 根目录，然后进入 `game/csgo`。
+
+   <img width="405" height="256" alt="进入 CS2 的 game/csgo 目录" src="https://github.com/user-attachments/assets/ae2be90e-6742-4f1f-8e0c-096b728d5dbd" />
+
+4. 复制已解压安装包中的其余全部文件，并粘贴到 `game/csgo`。
+
+   <img width="540" height="181" alt="将 Windows 版插件文件复制到 game/csgo" src="https://github.com/user-attachments/assets/6a8645fc-78e7-4f3a-92d3-5d1b6d913918" />
+
+5. 打开 **Panel v1.4.3.exe**，选择 **Bot Mode**，然后点击 **Launch CS2**。
+
+   <img width="339" height="129" alt="在 Panel 中选择 Bot Mode 并启动 CS2" src="https://github.com/user-attachments/assets/dc806991-c940-43cf-a614-f49012fae4a7" />
+
+### Linux
+
+1. 在[最新版本](https://github.com/ed0ard/CS2-Bot-Improver/releases/latest)中下载 **CS2BotImprover_for_Linux.zip** 并解压。
+2. 将 **Commands.txt** 放在方便使用的任意位置。
+3. 打开 CS2 根目录，然后进入 `game/csgo`。
+
+   <img width="405" height="256" alt="进入 CS2 的 game/csgo 目录" src="https://github.com/user-attachments/assets/ae2be90e-6742-4f1f-8e0c-096b728d5dbd" />
+
+4. 复制已解压安装包中的其余全部文件，并粘贴到 `game/csgo`。
+
+   <img width="535" height="180" alt="将 Linux 版插件文件复制到 game/csgo" src="https://github.com/user-attachments/assets/9bda7b1d-43d3-49cf-a283-27b124b894e0" />
+
+5. 在启动选项中添加 `-insecure`。
+
+   <img width="130" height="153" alt="打开 CS2 启动选项" src="https://github.com/user-attachments/assets/4c775e36-3fc3-4a19-9cb1-4f0c9327838c" /><br>
+   <img width="625" height="423" alt="在启动选项中添加 insecure 参数" src="https://github.com/user-attachments/assets/ac0b0c57-ee67-4e33-96fb-146d14714fc8" />
+
+## 命令
+
+### 瞄准
+
+| 命令 | 说明 |
+| --- | --- |
+| `bot_aim mixed` | 机器人根据战况灵活选择瞄准位置（默认） |
+| `bot_aim head` | 机器人优先瞄准头部 |
+| `bot_aim body` | 机器人优先瞄准躯干 |
+| `bot_aim` | 查看当前瞄准模式 |
+
+### 投掷物
+
+| 命令 | 说明 |
+| --- | --- |
+| `bot_nades off` | 机器人不会使用任何投掷物 |
+| `bot_nades less` | 使用与普通模式相同的决策逻辑，但数量限制更低 |
+| `bot_nades normal` | 数量限制与真人玩家基本相同（默认） |
+| `bot_nades more` | 使用与普通模式相同的决策逻辑，但数量限制更高 |
+| `bot_nades max` | 限制最少，机器人在投掷前的思考也更少 |
+| `bot_nades` | 查看当前投掷物使用模式 |
+
+### 皮肤
+
+| 命令 | 说明 |
+| --- | --- |
+| `br_reroll` | 在所有机器人下次生成时重新随机分配其皮肤 |
+
+### 购买
+
+在控制台中输入武器名称，即可从下一回合开始让所有机器人获得该武器。
+
+可用的武器名称：
+
+```text
+elite    p250     fn57      deagle    cz75a    r8
+bizon    p90      mp5sd     mp9       mp7      mac10
+ump45    mag7     sawedoff  nova      xm1014   famas
+galilar  m4a1     m4a1s     ak47      aug      sg556
+ssg08    awp      scar20    g3sg1     negev    m249
+```
+
+输入 `bot_buy` 后，机器人将恢复正常购买。
+
+### 战队
+
+如需在对局中加入职业战队，请从 [`Commands.txt`](../Commands.txt) 复制对应命令并粘贴到游戏控制台。你也可以按照相同格式添加新战队。
+
+例如，如果要将 Vit 加入 CT 阵营，请复制下图中的命令：
+
+<img width="301" height="237" alt="将 Vit 加入 CT 阵营的示例命令" src="https://github.com/user-attachments/assets/a895f3a6-58f8-47dc-b6f5-b60c1b32fecd" />
+
+### 刀具
+
+将准星对准地面并按下键盘上的 `\`，即可在该位置生成各种刀具。
+
+### Flying Scoutsman
+
+| 命令 | 说明 |
+| --- | --- |
+| `scouts_on` | 开启 Flying Scoutsman |
+| `scouts_off` | 关闭 Flying Scoutsman |
+
+请在对局开始后输入以上命令。
+
+## Panel 使用指南（仅限 Windows）
+
+### 状态指示灯
+
+| 状态 | 含义 |
+| --- | --- |
+| 🟢 | 未检测到问题 |
+| 🟡 | 重启 CS2 以应用更改 |
+| 🔴 | 文件缺失；点击红灯可查看缺失文件列表 |
+
+<img width="481" height="82" alt="Panel 状态指示灯" src="https://github.com/user-attachments/assets/26a947e2-4e0e-423f-bce8-f220d88509a2" />
+
+### 联机模式与机器人模式切换
+
+选择所需模式，然后点击 `Launch CS2`。
+
+<img width="472" height="179" alt="切换 Online Mode 与 Bot Mode" src="https://github.com/user-attachments/assets/3f9254fa-4cbe-4854-8fd1-0f35228fff77" />
+
+### 设置
+
+点击右上角的 <img width="31" height="32" alt="设置图标" src="https://github.com/user-attachments/assets/7f94176b-79f1-4e22-9495-4589c4dea9eb" /> 图标以打开 `Settings`。
+
+### 命令
+
+点击 `Commands` 后，点击任一命令块即可自动复制，也可以输入关键词搜索。
+
+<img width="350" height="420" alt="Panel 命令搜索与复制界面" src="https://github.com/user-attachments/assets/957cfafb-900d-4450-b985-13d3e8efc375" />
+
+## 常见问题
+
+<details>
+<summary><strong>如何与好友一起游玩机器人对局？</strong></summary>
+
+1. 创建机器人对局并输入所需命令，然后在控制台中输入 `status`。
+
+   <img width="597" height="141" alt="在控制台中运行 status" src="https://github.com/user-attachments/assets/792c4b4f-1d56-4a39-9186-b301cbff1846" />
+
+2. 复制 `steamid:` 后面的文本，并在前面加上 `connect `（不要漏掉中间的空格）。
+3. 将完整命令发送给好友，让他们粘贴到各自的控制台中。
+
+</details>
+
+<details>
+<summary><strong>如何手动更改难度？</strong></summary>
+
+1. 打开 CS2 根目录，然后进入 `game/csgo/overrides`。
+2. 根据需要打开对应文件夹：`Low` 为简单难度；`Medium` 为基于 HLTV 数据的混合难度（默认）；`High` 为极高难度。
+3. 启动游戏前，复制其中的 `botprofile.vpk` 并粘贴到 `game/csgo/overrides`。
+
+</details>
+
+<details>
+<summary><strong>如何手动切换回普通在线匹配模式？</strong></summary>
+
+1. 打开 CS2 根目录，然后进入 `game/csgo/backup/Online`。
+2. 复制 `gameinfo.gi` 并粘贴到 `game/csgo`，替换目标位置的文件。
+3. 从启动选项中删除 `-insecure`。
+
+修改后，如果想要**再次游玩机器人对局**，请进入 `game/csgo/backup/WithBots`，按照上述方式替换文件，并重新添加该启动选项。
+
+</details>
+
+<details>
+<summary><strong>如何手动禁用机器人的武器皮肤、探员皮肤、音乐盒、刀具和手套？</strong></summary>
+
+1. 打开 CS2 根目录，然后进入 `game/csgo/addons/counterstrikesharp/plugins`。
+2. 将 `BotRandomizer` 文件夹重命名为 `BotRandomizer_disabled`。
+3. 打开 `addons/counterstrikesharp/configs/core.json`，将 `FollowCS2ServerGuidelines` 设置为 `true`。
+
+</details>
+
+<details>
+<summary><strong>如何手动禁用机器人的 Steam 个人资料？</strong></summary>
+
+1. 打开 CS2 根目录，然后进入 `game/csgo/addons`。
+2. 将 `BotHider` 文件夹重命名为 `BotHider_disabled`。
+
+</details>
+
+<details>
+<summary><strong>如何让插件在创意工坊地图上正常运行？</strong></summary>
+
+在启动选项中添加 `-disable_workshop_command_filtering`。
+
+</details>
+
+<details>
+<summary><strong>如何正常进行滑翔（Surf）？</strong></summary>
+
+在游戏控制台中运行 `sv_standable_normal 0.7`。
+
+</details>
+
+### 可以在哪些场景中安全使用本项目？
+
+> [!WARNING]
+> 本项目适用于离线机器人对局、由用户自行托管的好友私人对局及私人专用服务器。自动饰品分配路径仅以机器人为处理对象，不以真人玩家的库存或饰品为处理目标；这一边界旨在遵循 [Valve 的 CS2 GSLT 规则](https://help.steampowered.com/zh-cn/faqs/view/07AF-502E-A104-BD4B)。
+>
+> 请勿将本项目用于 Valve 官方匹配、启用 VAC 的公共服务器、[FACEIT](https://support.faceit.com/hc/en-us/articles/360015788779-What-is-deemed-to-be-a-cheat)、第三方公共社区服务器，或用于规避任何反作弊或安全控制。进入上述服务前，请在 Panel 中切换回**联机模式（Online Mode）**，或手动恢复正常游戏文件、移除 `-insecure`，并重启 CS2。[AGPL-3.0 许可证](../LICENSE)授予的权利不构成违反平台或服务器规则的授权。在适用法律允许的最大范围内，用户应自行承担超出上述范围使用所产生的责任，以及由此导致的 GSLT、服务器、FACEIT、VAC、游戏或账号处罚。本声明仅供说明，不构成法律意见。
+
+## 致谢
+
+- [metamod-source](https://github.com/alliedmodders/metamod-source)
+- [CounterStrikeSharp](https://github.com/roflmuffin/CounterStrikeSharp)
+- [Ray-Trace](https://github.com/FUNPLAY-pro-CS2/Ray-Trace)
+- [CS2-Bullseye-Bot](https://github.com/ed0ard/CS2-Bullseye-Bot)
+- [CS2-Bot-NadeSystem](https://github.com/ed0ard/CS2-Bot-NadeSystem)
+- [CS2_ExecAfter_No_Admin](https://github.com/ed0ard/CS2_ExecAfter_No_Admin)，fork 自 [kus](https://github.com/kus)
+- [CS2-Bot-Randomizer](https://github.com/ed0ard/CS2-Bot-Randomizer)
+- [CS2-Lib](https://github.com/ianlucas/cs2-lib)，作者 [Lucas](https://github.com/ianlucas)
+- [CS2-Bot-Hider](https://github.com/XBribo/CS2-Bot-Hider)，作者 [XBribo](https://github.com/XBribo)
+- [CS2-Bot-Controller](https://github.com/XBribo/CS2-Bot-Controller)，作者 [XBribo](https://github.com/XBribo)
+- [CSGOBetterBots](https://github.com/manicogaming/CSGOBetterBots/blob/master/addons/sourcemod/data/bot_info.json)，作者 [manico](https://github.com/manicogaming)
+- [CS2-Smarter-Bot](https://github.com/ed0ard/CS2-Smarter-Bot)
+- [CS2-BotAI](https://github.com/ed0ard/CS2-BotAI)，fork 自 [Austin](https://github.com/Austinbots)
+- [CS2-BotAI-for-Linux](https://github.com/Austinbots/CS2-BotAI)
+- [CS2-Bot-Buy](https://github.com/ed0ard/CS2-Bot-Buy)
+- [RoundDamageRecap](https://github.com/YuGeYu/LBTV-CS2-Bot-Enhancer/tree/main/addons/counterstrikesharp/plugins/RoundDamageRecap)，作者 [YuGeYu](https://github.com/YuGeYu)
+- [Apple-Style-GUI](https://github.com/ed0ard/Apple-Style-GUI)
+
+## 许可证
+
+本项目采用 [AGPL-3.0](../LICENSE) 许可证。


### PR DESCRIPTION
## 改动内容

- 重新设计英文 README：增加更清晰的项目页头、Release 与许可证徽章、快速导航、功能与命令表格，以及可折叠的参考内容
- 在 `docs/` 中新增完整的简体中文和俄语文档，并为三种语言提供相互跳转入口
- 完整保留现有安装步骤、Panel 指南、命令、FAQ、截图、致谢，以及好友私人房和专用服务器说明
- 修正 Linux 文档中已经确认的文件名错误：`Command.txt` → `Commands.txt`，并明确安装文件来自解压后的安装包
- 明确正常的离线／私人机器人对局与官匹、反作弊保护公共服务之间的使用边界

## 改动原因

原 README 已经包含必要信息，但整体排版偏手工堆叠，内容较难快速浏览，而且只有英文版本。本次调整在不改变插件及其运行行为的前提下，改善文档层级、可读性和多语言支持。

## 用户影响

仓库仍默认显示英文 README。中文和俄语用户可以从页头切换语言；所有用户都能获得更清晰的安装步骤、便于检索的命令表格、结构更明确的 FAQ，以及指向最新 Release 和许可证的直接链接。

## 验证

- 通过 GitHub GFM Markdown API 实际渲染三份文档
- 验证标题、表格、折叠区、图片、警告框及非 ASCII 锚点链接
- 验证全部语言互链，以及 `Commands.txt` 和 `LICENSE` 的本地链接
- 确认每个语言版本均保留全部已记录命令、30 个武器别名、14 张截图，以及好友私人房和专用服务器说明
- 运行 `git diff --cached --check`

本 PR 不修改任何运行时代码或 Release 资源。
