### PR TITLE
fix(BotAI): apply cave patch pairs atomically to prevent Linux segfault

### DIFF
--- a/addons/counterstrikesharp/plugins/BotAI/BotAI.cs
+++ b/addons/counterstrikesharp/plugins/BotAI/BotAI.cs
@@ -25,7 +25,7 @@ public static class BotOffsets
 public class BotAI : BasePlugin
 {
     public override string ModuleName => "Patches - Bot AI";
-    public override string ModuleVersion => "1.8.7";
+    public override string ModuleVersion => "1.8.8";
     public override string ModuleAuthor => "K4ryuu & Austin (updated by ed0ard & Misaka17032 & XBribo & AmagiReina)";
     public override string ModuleDescription =>
         "Improve and fix bots' behavior comprehensively";
@@ -40,10 +40,48 @@ public class BotAI : BasePlugin
         Logger.LogInformation("Bot AI Patches loading...");
         var patchDefinitions = _isLinux ? LinuxPatchDefinitions.All : WindowsPatchDefinitions.All;
 
+        // "<name>_Cave" entries build a code cave that their "<name>" partner then
+        // jumps into with a fixed displacement. The pair must be applied atomically:
+        // if the cave is missing (e.g. its signature no longer matches after a game
+        // update), the partner's jump lands in unpatched bytes and the server
+        // segfaults as soon as a bot takes that code path.
+        var caveNames = patchDefinitions.Keys.Where(n => n.EndsWith("_Cave")).ToHashSet();
+        var appliedCaves = new HashSet<string>();
+
+        foreach (var name in caveNames)
+        {
+            if (ApplyPatch(name, _isLinux)) { appliedCaves.Add(name); Logger.LogInformation($"{name}: applied."); }
+            else Logger.LogError($"{name}: FAILED.");
+        }
+
         foreach (var name in patchDefinitions.Keys)
         {
+            if (caveNames.Contains(name)) continue;
+
+            string caveName = $"{name}_Cave";
+            if (caveNames.Contains(caveName) && !appliedCaves.Contains(caveName))
+            {
+                Logger.LogWarning($"{name}: skipped, its cave partner '{caveName}' did not apply.");
+                continue;
+            }
+
             if (ApplyPatch(name, _isLinux)) Logger.LogInformation($"{name}: applied.");
-            else Logger.LogError($"{name}: FAILED.");
+            else
+            {
+                Logger.LogError($"{name}: FAILED.");
+                // Roll back the now-orphaned cave so we never leave half a pair behind.
+                if (appliedCaves.Contains(caveName))
+                {
+                    var cave = _appliedPatches.FirstOrDefault(p => p.Name == caveName);
+                    if (cave != null)
+                    {
+                        RestorePatch(cave);
+                        _appliedPatches.Remove(cave);
+                        appliedCaves.Remove(caveName);
+                        Logger.LogWarning($"{caveName}: rolled back, its partner '{name}' did not apply.");
+                    }
+                }
+            }
         }
 
         RegisterEventHandler<EventPlayerSpawn>((@event, info) =>


### PR DESCRIPTION
## Summary

On Linux, BotAI applies "cave pair" patches non-atomically. When a CS2 update shifts `libserver.so` so that a `_Cave` signature no longer matches, the cave patch fails — but its partner patch (a `jmp` with a fixed displacement into that cave) is still applied. The jump then lands in unpatched bytes and the server segfaults as soon as any bot takes that code path. This PR makes cave pairs atomic: caves are applied first, a partner whose cave failed is skipped, and a cave whose partner failed is rolled back.

## The crash (reproducible on current Linux dedicated server build)

Setup: v1.4.3 Linux release, Ubuntu 24.04, CSS v1.0.371, DM with `bot_quota fill`. The server segfaults within a few minutes of bots engaging. `coredumpctl` stack (identical across all crashes):

```
#4  libserver.so + 0xc0d50f   <- faulting PC
#5  libserver.so + 0xc87579
#6  libserver.so + 0xc10af6
#7  libserver.so + 0xc7458b
#8  libserver.so + 0xc08248
#9  libserver.so + 0xec6da1
#10 libserver.so + 0x18dd4bb
#11 counterstrikesharp.so + 0xf697d
```

## Root cause

BotAI's load log on the same boot shows:

```
[EROR] 'Vision_AlwaysWatchApproachPoints_Cave': signature not found.
[EROR] Vision_AlwaysWatchApproachPoints_Cave: FAILED.
[INFO] 'Vision_AlwaysWatchApproachPoints' patched at 0x7E8CCC9F7525 (6 bytes).
[INFO] Vision_AlwaysWatchApproachPoints: applied.
```

The cave's CC-padding signature no longer exists in the current `libserver.so` (that region now contains real code), so the cave was never built. But the partner patch still wrote its jump:

- Patch bytes: `E9 E0 5F 01 00` = `jmp +0x15FE0`
- Jump site: `libserver.so + 0xBF7525`
- Landing: `0xBF7525 + 5 + 0x15FE0` = **`libserver.so + 0xC0D50A`** — the address where the cave *would* have been.

Disassembling the landing zone in the core dump (these are live `mov byte ptr [rbx+0x5Axx], 0` sequences entered mid-instruction, not a cave):

```
0xC0D50A:  add %al,%dh
0xC0D50C:  adc $0x5a,%esp
0xC0D50F:  add %al,(%rax)     <- faulting instruction, matches crash PC exactly
```

The faulting PC in every core is `+0xC0D50F` — five bytes past the dead cave entry. The trigger is any bot entering `CCSBot::UpdateLookAround`'s approach-points path, which happens quickly in DM.

Note the same class of protection already exists for byte-validated patches — e.g. `TBot_BombsiteSearch_UseKnownPlantedSite` was correctly rejected on this build (`byte mismatch. Expected [E8 5C 20 F6 FF] got [E8 3C 20 F6 FF]`). Cave patches can't benefit from that check because their expected-original is just CC padding, so the pairing has to be enforced structurally.

## Fix

In `Load()`:

1. Apply all `*_Cave` entries first.
2. Skip any patch whose `<name>_Cave` partner exists in the definitions but did not apply (logged as a warning instead of silently proceeding).
3. If a partner fails after its cave applied, restore the cave and remove it from the applied list, so `Unload()` stays consistent and no half-pair remains.

No behavior change on Windows (the Windows definitions contain no `_Cave` entries) or on Linux builds where all signatures match.

## Testing

- Built and deployed on the affected server: load log now shows `Vision_AlwaysWatchApproachPoints: skipped, its cave partner 'Vision_AlwaysWatchApproachPoints_Cave' did not apply.` and `Applied 40/43 patches.`
- Soaked with 14 bots in FFA deathmatch (the previous crash reproduced within ~4 minutes every time): no segfaults, no new core dumps.
- The two still-applied cave pairs (`Vision_AlwaysEnterApproachBody`, `Vision_AlwaysWatchApproachPoints_LoopEntry`) continue to work as before.

## Related observation (not addressed here)

Patches that write `call`/`jmp` displacements as fixed bytes (the cave jumps, `TBot_BombsiteSearch_UseKnownPlantedSite`'s `E8 6C 1D F6 FF`) hardcode the distance between two locations that each drift independently across game updates. Even when both signatures match, the distance can change. Computing displacements at patch time from the two resolved addresses would remove that whole failure class — happy to follow up with that in a separate PR if you're interested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
