### PR TITLE
feat(bot-ai): add configurable patch modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ On Windows, please download **CS2BotImprover_rules_unchanged.zip** to preserve t
 | `bot_nades max` | Bots have minimal limitations and think less before throwing nades. |
 | `bot_nades` | Show the current nade mode. |
 
+### Bot awareness
+
+BotAI's extended FOV, global hearing, and aggressive noise-investigation patches are disabled by default. The plugin configuration is generated at:
+
+`game/csgo/addons/counterstrikesharp/configs/plugins/BotAI/BotAI.json`
+
+```json
+{
+  "CasualAwareness": true,
+  "ConfigVersion": 1
+}
+```
+
+Set `CasualAwareness` to `false` to apply the upstream extended-awareness patches. Reload BotAI or restart the server after changing this setting; memory patches are not switched while the plugin is running.
+
 ### Skins
 
 | Command | Description |

--- a/README.md
+++ b/README.md
@@ -95,20 +95,104 @@ On Windows, please download **CS2BotImprover_rules_unchanged.zip** to preserve t
 | `bot_nades max` | Bots have minimal limitations and think less before throwing nades. |
 | `bot_nades` | Show the current nade mode. |
 
-### Bot awareness
+### Bot AI modules
 
-BotAI's extended FOV, global hearing, and aggressive noise-investigation patches are disabled by default. The plugin configuration is generated at:
+Every BotAI patch belongs to a documented module group. Toggle whole groups in the config file, or list individual patch names for fine-grained control:
 
 `game/csgo/addons/counterstrikesharp/configs/plugins/BotAI/BotAI.json`
 
 ```json
 {
-  "CasualAwareness": true,
-  "ConfigVersion": 1
+  "ConfigVersion": 2,
+  "Modules": {
+    "Awareness": false,
+    "BombInfo": false,
+    "CombatForce": true,
+    "Movement": true,
+    "VisionAttention": true,
+    "BombBehavior": true,
+    "StateMachine": true
+  },
+  "DisabledPatches": []
 }
 ```
 
-Set `CasualAwareness` to `false` to apply the upstream extended-awareness patches. Reload BotAI or restart the server after changing this setting; memory patches are not switched while the plugin is running.
+| Module | What it does | Recommended |
+| --- | --- | --- |
+| `Awareness` | Superhuman perception: unlimited vision cones, global hearing, aggressive noise investigation. Makes bots wallhack-ish. | `false` for casual fair play |
+| `BombInfo` | Global C4 intel: pickup/beeps heard anywhere and instant site knowledge on plant. Deletes the post-plant information game. | `false` for casual fair play |
+| `CombatForce` | Forced combat: no fire-rate limit, hold-trigger sprays at any range, 100% dodge chance (dice removed). | `true` if you want strong bots; `false` if gunfights feel unfair |
+| `Movement` | Movement quality fixes: strafing unlocked, dodge while reloading, anti-sniper movement. Vanilla randomness kept. | `true` |
+| `VisionAttention` | Vision/attention enhancements: watching approach points, always noticing enemies. | `true` |
+| `BombBehavior` | Plant/defuse behavioral fixes (stop pulling knife out, fight back while defusing). Pure realism. | `true` |
+| `StateMachine` | Misc state fixes, including removing built-in flash avoidance so bots can be blinded like humans. | `true` |
+
+- `DisabledPatches` lists individual patch names to skip on top of module toggles; unknown names are reported at load time.
+- Legacy `CasualAwareness` (ConfigVersion 1) is still honored: `true` forces the Awareness group off even when `Modules.Awareness` is true. Remove the field to rely on `Modules` alone.
+- Memory patches are applied at load time only — restart or reload the plugin after changing this file.
+
+#### Per-patch reference
+
+<details>
+<summary><strong>All BotAI patches grouped by module</strong></summary>
+
+| Patch | What it changes |
+| --- | --- |
+| **Awareness** ⛔ superhuman perception | |
+| `InViewCone_RemoveOuterFOV` | Removes the outer vision-cone limit (bots see almost all around them) |
+| `InViewCone_RemoveInnerFOV` | Removes the inner vision-cone limit |
+| `OnAudibleEvent_GlobalHearRange` | Bots hear audible events from anywhere on the map |
+| `InvestigateNoise_SkipSelfDefenseCheck` | Bots investigate noises without the self-defense check |
+| **BombInfo** ⛔ global C4 intel | |
+| `BombPickup_CT_GlobalHearRange` | CT bots hear the bomb pickup anywhere on the map |
+| `BombBeep_CT_GlobalHearRange` | CT bots hear bomb beeps anywhere on the map |
+| `OnBombPlanted_AllBotsLearnSite` | Every bot instantly learns the planted site when the bomb goes down |
+| **CombatForce** forced combat | |
+| `AttackState_SkipFireRateCheck` | Removes the fire-rate gate — bots can shoot every simulation tick |
+| `AttackState_SkipSteadyFireShortcut` | No early exit from the steady-fire routine (longer sprays) |
+| `AttackState_SkipZoomFireShortcut` | No early exit from the zoom-fire routine |
+| `SprayAllDistances_ForceHoldTrigger` | Holds the trigger continuously at any range (no burst discipline) |
+| `AttackState_DodgeChance100_Always` | Removes the dodge dice roll — always takes the high-skill dodge path |
+| `AttackState_RetreatOnSniper_Disable` | Stops retreating just because an enemy sniper is visible |
+| `AttackState_SkipSniperSpreadCheck` | Skips extra weapon spread when engaging snipers |
+| **Movement** realism fixes (vanilla randomness kept) | |
+| `AttackState_CanStrafe_jne` | Unlocks strafing while attacking |
+| `AttackState_DodgeDuringReload` | Allows dodging while reloading |
+| `SniperCrouchDodge_jb` | Crouch-dodge reaction against snipers |
+| `SniperDodge_SkipIsSniper_DodgeA` | Any bot can use the anti-sniper dodge moves |
+| `AllSkill_KeepMoving_WhenSeeSniper` | Keeps moving when spotting a sniper (all skill levels) |
+| `LowSKill_JumpChance0` | Removes random jumping for low-skill bots (less silly randomness) |
+| **VisionAttention** | |
+| `Vision_SkipIsMovingGate` | Bots notice targets even while moving themselves |
+| `Vision_AlwaysEnterApproachBody_Cave` | Always enter approach-body attention nodes (cave variant) |
+| `Vision_AlwaysEnterApproachBody` | Always enter approach-body attention nodes |
+| `Vision_AlwaysWatchApproachPoints_Cave` | Always watch approach points (cave variant) |
+| `Vision_AlwaysWatchApproachPoints` | Always watch approach points |
+| `Vision_AlwaysWatchApproachPoints_LoopEntry_Cave` | Always watch approach-point loop entries (cave variant) |
+| `Vision_AlwaysWatchApproachPoints_LoopEntry` | Always watch approach-point loop entries |
+| `Vision_ApproachBody_SkipSkillCheck` | Ignore the skill threshold before approach-body checks (Windows) |
+| `Vision_ApproachBody_SkipHidingSpotCheck` | Watch bodies without hiding-spot filtering |
+| `IsNoticable_AlwaysTrue` | Bots always notice enemies — stealth and flanking lose their effect |
+| **BombBehavior** realism fixes | |
+| `EscapeFromBomb_OnEnter_NoEquipKnife` | Don't pull the knife out when escaping a planted bomb |
+| `EscapeFromBomb_OnUpdate_NoEquipKnife` | Same as above, enforced every update tick |
+| `EscapeFromFlames_OnEnter_NoEquipKnife` | Don't pull the knife out when escaping Molotov flames |
+| `PlantBombLookAtPriorityLow` | Lower look-at priority while planting (watch surroundings instead) |
+| `DefuseBombLookAtPriorityLow` | Lower look-at priority while defusing |
+| `DefuseBomb_SkipIsVisibleCheck` | Can start defusing without a line-of-sight ceremony |
+| `TBot_BombsiteSearch_UseKnownPlantedSite` | T bots search the known planted site first |
+| `CT_Defuse_EngageAndInvestigate` | CTs engage nearby enemies then continue the defuse |
+| `DefuseBombState_OnEnter_EngageAndInvestigate` | Fight back when entering the defuse state |
+| `DefuseBombState_OnUpdate_EngageAndInvestigate` | Fight back throughout the defuse state |
+| **StateMachine** misc fixes | |
+| `HasVisitedEnemySpawn` | Bots remember visited enemy spawns for smarter searching |
+| `GameState_Reset` | Properly reset bot game state between rounds/phases |
+| `Idle_IsSafeAlwaysFalse` | Idle bots no longer assume their spot is safe (stay alert) |
+| `FlashbangAvoidance_Disable` | Removes built-in flash avoidance so bots can be blinded like humans |
+| `Upkeep_BotCOS_ZeroDrift` | Removes cosine-based idle look drift (Windows) |
+| `Upkeep_BotSIN_ZeroDrift` | Removes sine-based idle look drift (Windows) |
+
+</details>
 
 ### Skins
 

--- a/addons/counterstrikesharp/plugins/BotAI/BotAI.cs
+++ b/addons/counterstrikesharp/plugins/BotAI/BotAI.cs
@@ -35,33 +35,29 @@ public class BotAI : BasePlugin, IPluginConfig<BotAIConfig>
 
     private readonly List<PatchInfo> _appliedPatches = [];
     private readonly bool _isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-    private static readonly HashSet<string> ExtendedAwarenessPatches =
-    [
-        "InViewCone_RemoveOuterFOV",
-        "InViewCone_RemoveInnerFOV",
-        "OnAudibleEvent_GlobalHearRange",
-        "InvestigateNoise_SkipSelfDefenseCheck"
-    ];
 
     public BotAIConfig Config { get; set; } = new();
 
     public void OnConfigParsed(BotAIConfig config)
     {
-        Config = config;
+        Config = config ?? new BotAIConfig();
+        Config.Modules ??= new ModuleToggles();
+        Config.DisabledPatches ??= [];
     }
 
     public override void Load(bool hotReload)
     {
         Logger.LogInformation("Bot AI Patches loading...");
         var patchDefinitions = _isLinux ? LinuxPatchDefinitions.All : WindowsPatchDefinitions.All;
+        var disabledPatches = ResolveDisabledPatches(patchDefinitions.Keys);
         var skippedPatches = 0;
 
         foreach (var name in patchDefinitions.Keys)
         {
-            if (Config.CasualAwareness && ExtendedAwarenessPatches.Contains(name))
+            if (disabledPatches.Contains(name))
             {
                 skippedPatches++;
-                Logger.LogInformation($"{name}: skipped (CasualAwareness enabled).");
+                Logger.LogInformation($"{name}: skipped (disabled via config).");
                 continue;
             }
 
@@ -92,7 +88,65 @@ public class BotAI : BasePlugin, IPluginConfig<BotAIConfig>
 
         Logger.LogInformation(
             $"Applied {_appliedPatches.Count}/{patchDefinitions.Count - skippedPatches} enabled patches " +
-            $"({skippedPatches} extended awareness patches skipped).");
+            $"({skippedPatches} patches skipped by config).");
+    }
+
+    /// <summary>
+    /// Builds the effective skip set from module toggles, the legacy
+    /// CasualAwareness switch and the explicit DisabledPatches list.
+    /// Unknown names in DisabledPatches are reported (typo protection).
+    /// </summary>
+    private HashSet<string> ResolveDisabledPatches(IEnumerable<string> availablePatchNames)
+    {
+        var available = availablePatchNames.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var disabled = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void AddCategory(string category, string source)
+        {
+            if (!BotAIPatchCategories.All.TryGetValue(category, out var patches)) return;
+            var matched = 0;
+            foreach (var name in patches)
+            {
+                if (!available.Contains(name)) continue;
+                disabled.Add(name);
+                matched++;
+            }
+
+            if (matched > 0)
+                Logger.LogInformation($"Module '{category}' disabled via {source} ({matched} patches).");
+        }
+
+        // Legacy switch wins over Modules.Awareness when explicitly present.
+        if (Config.CasualAwareness.HasValue)
+        {
+            if (Config.CasualAwareness.Value)
+                AddCategory("Awareness", "CasualAwareness=true");
+        }
+        else if (!Config.Modules.Awareness)
+        {
+            AddCategory("Awareness", "Modules.Awareness=false");
+        }
+
+        if (!Config.Modules.BombInfo) AddCategory("BombInfo", "Modules.BombInfo=false");
+        if (!Config.Modules.CombatForce) AddCategory("CombatForce", "Modules.CombatForce=false");
+        if (!Config.Modules.Movement) AddCategory("Movement", "Modules.Movement=false");
+        if (!Config.Modules.VisionAttention) AddCategory("VisionAttention", "Modules.VisionAttention=false");
+        if (!Config.Modules.BombBehavior) AddCategory("BombBehavior", "Modules.BombBehavior=false");
+        if (!Config.Modules.StateMachine) AddCategory("StateMachine", "Modules.StateMachine=false");
+
+        foreach (var name in Config.DisabledPatches)
+        {
+            if (string.IsNullOrWhiteSpace(name)) continue;
+            if (!available.Contains(name))
+            {
+                Logger.LogWarning($"DisabledPatches: '{name}' does not match any known patch name (typo?).");
+                continue;
+            }
+
+            disabled.Add(name);
+        }
+
+        return disabled;
     }
 
     public override void Unload(bool hotReload)

--- a/addons/counterstrikesharp/plugins/BotAI/BotAI.cs
+++ b/addons/counterstrikesharp/plugins/BotAI/BotAI.cs
@@ -25,7 +25,7 @@ public static class BotOffsets
 }
 
 [MinimumApiVersion(304)]
-public class BotAI : BasePlugin
+public class BotAI : BasePlugin, IPluginConfig<BotAIConfig>
 {
     public override string ModuleName => "Patches - Bot AI";
     public override string ModuleVersion => "1.8.8";
@@ -35,16 +35,36 @@ public class BotAI : BasePlugin
 
     private readonly List<PatchInfo> _appliedPatches = [];
     private readonly bool _isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+    private static readonly HashSet<string> ExtendedAwarenessPatches =
+    [
+        "InViewCone_RemoveOuterFOV",
+        "InViewCone_RemoveInnerFOV",
+        "OnAudibleEvent_GlobalHearRange",
+        "InvestigateNoise_SkipSelfDefenseCheck"
+    ];
 
+    public BotAIConfig Config { get; set; } = new();
 
+    public void OnConfigParsed(BotAIConfig config)
+    {
+        Config = config;
+    }
 
     public override void Load(bool hotReload)
     {
         Logger.LogInformation("Bot AI Patches loading...");
         var patchDefinitions = _isLinux ? LinuxPatchDefinitions.All : WindowsPatchDefinitions.All;
+        var skippedPatches = 0;
 
         foreach (var name in patchDefinitions.Keys)
         {
+            if (Config.CasualAwareness && ExtendedAwarenessPatches.Contains(name))
+            {
+                skippedPatches++;
+                Logger.LogInformation($"{name}: skipped (CasualAwareness enabled).");
+                continue;
+            }
+
             if (ApplyPatch(name, _isLinux)) Logger.LogInformation($"{name}: applied.");
             else Logger.LogError($"{name}: FAILED.");
         }
@@ -70,7 +90,9 @@ public class BotAI : BasePlugin
             return HookResult.Continue;
         });
 
-        Logger.LogInformation($"Applied {_appliedPatches.Count}/{patchDefinitions.Count} patches.");
+        Logger.LogInformation(
+            $"Applied {_appliedPatches.Count}/{patchDefinitions.Count - skippedPatches} enabled patches " +
+            $"({skippedPatches} extended awareness patches skipped).");
     }
 
     public override void Unload(bool hotReload)

--- a/addons/counterstrikesharp/plugins/BotAI/BotAIConfig.cs
+++ b/addons/counterstrikesharp/plugins/BotAI/BotAIConfig.cs
@@ -1,0 +1,11 @@
+using CounterStrikeSharp.API.Core;
+using System.Text.Json.Serialization;
+
+namespace BotAI;
+
+public sealed class BotAIConfig : BasePluginConfig
+{
+    // Keep the extended awareness patches disabled by default for a fairer bot experience.
+    [JsonPropertyName("CasualAwareness")]
+    public bool CasualAwareness { get; set; } = true;
+}

--- a/addons/counterstrikesharp/plugins/BotAI/BotAIConfig.cs
+++ b/addons/counterstrikesharp/plugins/BotAI/BotAIConfig.cs
@@ -3,9 +3,56 @@ using System.Text.Json.Serialization;
 
 namespace BotAI;
 
+/// <summary>
+/// Module-level toggles. Each switch controls a whole group of related
+/// patches; see BotAIPatchCategories.All for the exact membership.
+/// </summary>
+public sealed class ModuleToggles
+{
+    /// <summary>Superhuman perception: unlimited vision cones + global hearing + aggressive noise investigation. Default false for casual fair play.</summary>
+    public bool Awareness { get; set; } = false;
+
+    /// <summary>Global C4 intel: pickup/beeps heard anywhere on the map and instant site knowledge on plant. Default false — this removes the post-plant information game.</summary>
+    public bool BombInfo { get; set; } = false;
+
+    /// <summary>Forced combat behavior: no fire-rate limit, hold-trigger sprays at any range, 100% dodge chance. Default true (upstream behavior).</summary>
+    public bool CombatForce { get; set; } = true;
+
+    /// <summary>Movement quality fixes: strafing unlocked, reload dodging, anti-sniper movement. Keeps vanilla randomness. Default true.</summary>
+    public bool Movement { get; set; } = true;
+
+    /// <summary>Vision/attention enhancements: watching approach points, always noticing enemies. Default true.</summary>
+    public bool VisionAttention { get; set; } = true;
+
+    /// <summary>Bomb plant/defuse behavioral fixes (realism only, no information cheats). Default true.</summary>
+    public bool BombBehavior { get; set; } = true;
+
+    /// <summary>Misc state machine fixes, including removing the built-in flash avoidance so bots can be blinded like humans. Default true.</summary>
+    public bool StateMachine { get; set; } = true;
+}
+
 public sealed class BotAIConfig : BasePluginConfig
 {
-    // Keep the extended awareness patches disabled by default for a fairer bot experience.
+    [JsonPropertyName("ConfigVersion")]
+    public override int Version { get; set; } = 2;
+
+    /// <summary>
+    /// Legacy switch kept for backward compatibility with ConfigVersion 1 files.
+    /// null  -> Modules.Awareness decides.
+    /// true  -> Awareness patches are skipped even when Modules.Awareness is true.
+    /// false -> Awareness patches remain enabled for legacy compatibility.
+    /// Omit the field to let Modules.Awareness control the group.
+    /// </summary>
     [JsonPropertyName("CasualAwareness")]
-    public bool CasualAwareness { get; set; } = true;
+    public bool? CasualAwareness { get; set; } = null;
+
+    [JsonPropertyName("Modules")]
+    public ModuleToggles Modules { get; set; } = new();
+
+    /// <summary>
+    /// Individual patch names to skip regardless of module toggles.
+    /// Unknown names are logged as warnings at load time (typo protection).
+    /// </summary>
+    [JsonPropertyName("DisabledPatches")]
+    public List<string> DisabledPatches { get; set; } = [];
 }

--- a/addons/counterstrikesharp/plugins/BotAI/BotAIPatchCategories.cs
+++ b/addons/counterstrikesharp/plugins/BotAI/BotAIPatchCategories.cs
@@ -1,0 +1,94 @@
+namespace BotAI;
+
+/// <summary>
+/// Groups every patch into a documented module category so configs can toggle
+/// whole behaviors instead of individual signature names.
+/// Every patch belongs to exactly one category; unknown platform-specific
+/// names are ignored gracefully when resolving the disabled set.
+/// </summary>
+public static class BotAIPatchCategories
+{
+    public static readonly Dictionary<string, string[]> All = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Superhuman perception: unlimited vision cones and global hearing.
+        ["Awareness"] =
+        [
+            "InViewCone_RemoveOuterFOV",
+            "InViewCone_RemoveInnerFOV",
+            "OnAudibleEvent_GlobalHearRange",
+            "InvestigateNoise_SkipSelfDefenseCheck"
+        ],
+
+        // Global C4 intel: bots know bomb events from anywhere on the map.
+        ["BombInfo"] =
+        [
+            "BombPickup_CT_GlobalHearRange",
+            "BombBeep_CT_GlobalHearRange",
+            "OnBombPlanted_AllBotsLearnSite"
+        ],
+
+        // Forced combat behavior: removes fire-rate limits and dodge dice rolls.
+        ["CombatForce"] =
+        [
+            "AttackState_SkipFireRateCheck",
+            "AttackState_SkipSteadyFireShortcut",
+            "AttackState_SkipZoomFireShortcut",
+            "SprayAllDistances_ForceHoldTrigger",
+            "AttackState_DodgeChance100_Always",
+            "AttackState_RetreatOnSniper_Disable",
+            "AttackState_SkipSniperSpreadCheck"
+        ],
+
+        // Movement quality fixes: keeps vanilla randomness, unlocks abilities.
+        ["Movement"] =
+        [
+            "AttackState_CanStrafe_jne",
+            "AttackState_DodgeDuringReload",
+            "SniperCrouchDodge_jb",
+            "SniperDodge_SkipIsSniper_DodgeA",
+            "AllSkill_KeepMoving_WhenSeeSniper",
+            "LowSKill_JumpChance0"
+        ],
+
+        // Vision/attention enhancements: approach watching and noticing.
+        ["VisionAttention"] =
+        [
+            "Vision_SkipIsMovingGate",
+            "Vision_AlwaysEnterApproachBody_Cave",
+            "Vision_AlwaysEnterApproachBody",
+            "Vision_AlwaysWatchApproachPoints_Cave",
+            "Vision_AlwaysWatchApproachPoints",
+            "Vision_AlwaysWatchApproachPoints_LoopEntry_Cave",
+            "Vision_AlwaysWatchApproachPoints_LoopEntry",
+            "Vision_ApproachBody_SkipSkillCheck",
+            "Vision_ApproachBody_SkipHidingSpotCheck",
+            "IsNoticable_AlwaysTrue"
+        ],
+
+        // Bomb plant/defuse behavioral fixes (pure realism, no info cheats).
+        ["BombBehavior"] =
+        [
+            "EscapeFromBomb_OnEnter_NoEquipKnife",
+            "EscapeFromBomb_OnUpdate_NoEquipKnife",
+            "EscapeFromFlames_OnEnter_NoEquipKnife",
+            "PlantBombLookAtPriorityLow",
+            "DefuseBombLookAtPriorityLow",
+            "DefuseBomb_SkipIsVisibleCheck",
+            "TBot_BombsiteSearch_UseKnownPlantedSite",
+            "CT_Defuse_EngageAndInvestigate",
+            "DefuseBombState_OnEnter_EngageAndInvestigate",
+            "DefuseBombState_OnUpdate_EngageAndInvestigate"
+        ],
+
+        // Misc state machine fixes, incl. removing built-in flash avoidance.
+        ["StateMachine"] =
+        [
+            "HasVisitedEnemySpawn",
+            "GameState_Reset",
+            "Idle_IsSafeAlwaysFalse",
+            "FlashbangAvoidance_Disable",
+            "Upkeep_BotCOS_ZeroDrift",
+            "Upkeep_BotSIN_ZeroDrift"
+        ]
+    };
+}


### PR DESCRIPTION
Adds configurable BotAI patch modules for awareness, bomb information, combat force, movement, vision/attention, bomb behavior, and state-machine fixes. Adds DisabledPatches overrides with unknown-name warnings, preserves ConfigVersion 1 CasualAwareness compatibility, and documents the generated ConfigVersion 2 format plus all patch names. Verified with a Release build: 0 warnings, 0 errors.