### PR TITLE
feat: add BotChat plugin - bots greet, say gg, and chat about kills

### DIFF
--- a/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
+++ b/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
@@ -1,10 +1,13 @@
-// BotChat plugin: bots greet at match start ("gl", "hf", ...) and wrap up
-// at match end ("gg", "ggs", ... , occasionally "ez").
+// BotChat plugin: bots greet at match start ("gl", "hf", ...), wrap up at
+// match end ("gg", "ggs", ... , occasionally "ez"), and react to kills:
+// a headshot victim may say "ns", a killer says thanks when dying or when
+// the round ends while still alive.
 //
 // Convars:
-//   botchat_enabled        - master switch (default 1)
-//   botchat_start_enabled  - greetings at match start (default 1)
-//   botchat_end_enabled    - goodbyes at match end (default 1)
+//   botchat_enabled              - master switch (default 1)
+//   botchat_start_enabled        - greetings at match start (default 1)
+//   botchat_end_enabled          - goodbyes at match end (default 1)
+//   botchat_killreactions_enabled - kill reactions (ns / thanks) (default 1)
 
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
@@ -18,10 +21,10 @@ namespace BotChat;
 public class BotChatPlugin : BasePlugin
 {
     public override string ModuleName => "BotChat";
-    public override string ModuleVersion => "1.0.0";
-    public override string ModuleAuthor => "ed0ard";
+    public override string ModuleVersion => "1.1.0";
+    public override string ModuleAuthor => "Fimall";
     public override string ModuleDescription =>
-        "Bots say a greeting at match start and a goodbye at match end";
+        "Bots greet at match start, say gg at match end, and chat about kills";
 
     // Messages a bot can greet with at match start (uniform pick).
     private static readonly (string message, int weight)[] StartMessages =
@@ -38,6 +41,19 @@ public class BotChatPlugin : BasePlugin
         ("ez", 5),
     };
 
+    // A headshot victim can compliment the shot (uniform pick).
+    private static readonly (string message, int weight)[] NiceShotMessages =
+    {
+        ("ns", 1), ("nc", 1), ("nice shot", 1),
+    };
+
+    // A killer thanks someone (uniform pick).
+    private static readonly (string message, int weight)[] ThanksMessages =
+    {
+        ("ty", 1), ("thanks", 1), ("thank u", 1), ("thx", 1),
+        ("life game", 1), ("luck", 1), (":)", 1),
+    };
+
     private const int MaxSpeakersPerTeam = 5;
 
     // Random gap between two bot messages (seconds). Keeps chat from looking
@@ -45,13 +61,22 @@ public class BotChatPlugin : BasePlugin
     private const float MinGap = 1.2f;
     private const float MaxGap = 3.0f;
 
+    // Base chance (0-1) a headshot victim says "ns" after death. Each kill
+    // type (blind, smoke, wallbang, jump) adds this much on top.
+    private const double NiceShotBaseChance = 0.05;
+    private const double NiceShotBuffPerKillType = 0.20;
+
     // Guards the end messages against double-firing: the final round's win
     // panel and the match win panel may both be dispatched by the engine.
     private bool _endSaid;
 
+    // Bots that killed someone this round, by slot. Used at round end.
+    private readonly HashSet<int> _killersThisRound = new();
+
     public FakeConVar<bool> Enabled = new("botchat_enabled", "Enable bot chat messages", true);
     public FakeConVar<bool> StartEnabled = new("botchat_start_enabled", "Bots greet at match start", true);
     public FakeConVar<bool> EndEnabled = new("botchat_end_enabled", "Bots say goodbye at match end", true);
+    public FakeConVar<bool> KillReactionsEnabled = new("botchat_killreactions_enabled", "Bots react to kills (ns / thanks)", true);
 
     public override void Load(bool hotReload)
     {
@@ -63,6 +88,9 @@ public class BotChatPlugin : BasePlugin
         // never be dispatched.
         RegisterEventHandler<EventCsWinPanelRound>(OnCsWinPanelRound);
         RegisterEventHandler<EventCsWinPanelMatch>(OnCsWinPanelMatch);
+        RegisterEventHandler<EventRoundStart>(OnRoundStart);
+        RegisterEventHandler<EventRoundEnd>(OnRoundEnd);
+        RegisterEventHandler<EventPlayerDeath>(OnPlayerDeath);
     }
 
     private HookResult OnBeginNewMatch(EventBeginNewMatch @event, GameEventInfo info)
@@ -101,6 +129,104 @@ public class BotChatPlugin : BasePlugin
         SayAcrossTeams(EndMessages, uniform: false, baseDelay: 1.5f);
     }
 
+    // Clears per-round kill tracking.
+    private HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
+    {
+        _killersThisRound.Clear();
+        return HookResult.Continue;
+    }
+
+    // Round end: bots that killed this round and are still alive say thanks.
+    private HookResult OnRoundEnd(EventRoundEnd @event, GameEventInfo info)
+    {
+        if (!Enabled.Value || !KillReactionsEnabled.Value)
+            return HookResult.Continue;
+
+        var aliveKillers = Utilities.FindAllEntitiesByDesignerName<CCSPlayerController>("cs_player_controller")
+            .Where(p => p.IsValid
+                && p.IsBot
+                && !p.IsHLTV
+                && !p.HasBeenControlledByPlayerThisRound
+                && p.PawnIsAlive
+                && _killersThisRound.Contains(p.Slot))
+            .ToList();
+        if (aliveKillers.Count == 0)
+            return HookResult.Continue;
+
+        SayRandom(aliveKillers, ThanksMessages, uniform: true, baseDelay: 0.8f);
+        return HookResult.Continue;
+    }
+
+    // Death reactions: the headshot victim may compliment, the killer thanks.
+    private HookResult OnPlayerDeath(EventPlayerDeath @event, GameEventInfo info)
+    {
+        if (!Enabled.Value || !KillReactionsEnabled.Value)
+            return HookResult.Continue;
+
+        var victim = @event.Userid;
+        var attacker = @event.Attacker;
+        if (victim == null || !victim.IsValid || !victim.IsBot || victim.IsHLTV)
+            return HookResult.Continue;
+
+        // 1) Victim: compliment a headshot (ns / nc / nice shot).
+        if (@event.Headshot)
+        {
+            double chance = NiceShotBaseChance;
+            if (@event.Attackerblind) chance += NiceShotBuffPerKillType;
+            if (@event.Thrusmoke) chance += NiceShotBuffPerKillType;
+            if (@event.Penetrated > 0) chance += NiceShotBuffPerKillType;
+            if (@event.Attackerinair) chance += NiceShotBuffPerKillType;
+
+            if (Random.Shared.NextDouble() < chance)
+            {
+                var killer = attacker;
+                AddTimer(0.6f, () => BotSay(victim, PickMessage(NiceShotMessages, uniform: true)));
+            }
+        }
+
+        // 2) Killer: thanks after dying.
+        if (attacker != null && attacker.IsValid && attacker.IsBot && !attacker.IsHLTV
+            && !attacker.HasBeenControlledByPlayerThisRound
+            && attacker.Slot != victim.Slot)
+        {
+            _killersThisRound.Add(attacker.Slot);
+            AddTimer(0.6f, () => BotSay(attacker, PickMessage(ThanksMessages, uniform: true)));
+        }
+
+        return HookResult.Continue;
+    }
+
+    // Picks 1..N random bots from a given list and staggers one message each.
+    private void SayRandom(
+        List<CCSPlayerController> bots,
+        (string message, int weight)[] pool,
+        bool uniform,
+        float baseDelay)
+    {
+        if (bots.Count == 0)
+            return;
+
+        int count = Math.Min(MaxSpeakersPerTeam, bots.Count);
+        int speakers = Random.Shared.Next(1, count + 1);
+
+        // Fisher-Yates shuffle, take the first `speakers`.
+        for (int i = bots.Count - 1; i > 0; i--)
+        {
+            int j = Random.Shared.Next(i + 1);
+            (bots[i], bots[j]) = (bots[j], bots[i]);
+        }
+
+        float delay = baseDelay;
+        for (int i = 0; i < speakers; i++)
+        {
+            var bot = bots[i];
+            string message = PickMessage(pool, uniform);
+            float scheduled = delay;
+            AddTimer(scheduled, () => BotSay(bot, message));
+            delay += MinGap + (float)Random.Shared.NextDouble() * (MaxGap - MinGap);
+        }
+    }
+
     // Picks 1..5 random bots per team (humans and taken-over bots excluded)
     // and makes each say one message, staggered in time.
     private void SayAcrossTeams((string message, int weight)[] pool, bool uniform, float baseDelay)
@@ -117,25 +243,7 @@ public class BotChatPlugin : BasePlugin
             if (bots.Count == 0)
                 continue;
 
-            int count = Math.Min(MaxSpeakersPerTeam, bots.Count);
-            int speakers = Random.Shared.Next(1, count + 1);
-
-            // Fisher-Yates shuffle, take the first `speakers`.
-            for (int i = bots.Count - 1; i > 0; i--)
-            {
-                int j = Random.Shared.Next(i + 1);
-                (bots[i], bots[j]) = (bots[j], bots[i]);
-            }
-
-            float delay = baseDelay;
-            for (int i = 0; i < speakers; i++)
-            {
-                var bot = bots[i];
-                string message = PickMessage(pool, uniform);
-                float scheduled = delay;
-                AddTimer(scheduled, () => BotSay(bot, message));
-                delay += MinGap + (float)Random.Shared.NextDouble() * (MaxGap - MinGap);
-            }
+            SayRandom(bots, pool, uniform, baseDelay);
         }
     }
 

--- a/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
+++ b/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
@@ -226,16 +226,14 @@ public class BotChatPlugin : BasePlugin
             AddTimer(0.6f, () => BotSay(victim, PickMessage(NiceShotMessages, uniform: true)));
         }
 
-        // 2) Complimented killer: reply thanks after dying (one reply only;
-        // the owed entry is consumed here so the round end won't repeat it).
-        if (attacker != null && attacker.IsValid && attacker.IsBot && !attacker.IsHLTV
-            && !attacker.HasBeenControlledByPlayerThisRound
-            && attacker.Slot != victim.Slot
-            && _owedThanks.Remove(attacker.Slot))
+        // 2) This victim, if it owed a thanks reply from an earlier ns, pays
+        // it back now that it died (one reply only; the owed entry is
+        // consumed so the round end won't repeat it).
+        if (_owedThanks.Remove(victim.Slot))
         {
             Console.WriteLine(
-                $"[BotChat] death-thanks: killer={attacker.PlayerName} (slot {attacker.Slot}) replies to {victimName}");
-            AddTimer(0.6f, () => BotSay(attacker, PickMessage(ThanksMessages, uniform: true)));
+                $"[BotChat] death-thanks: {victimName} (slot {victim.Slot}) replies to {attackerName}");
+            AddTimer(0.6f, () => BotSay(victim, PickMessage(ThanksMessages, uniform: true)));
         }
 
         return HookResult.Continue;

--- a/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
+++ b/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
@@ -40,6 +40,11 @@ public class BotChatPlugin : BasePlugin
 
     private const int MaxSpeakersPerTeam = 5;
 
+    // Random gap between two bot messages (seconds). Keeps chat from looking
+    // like a scripted burst.
+    private const float MinGap = 1.2f;
+    private const float MaxGap = 3.0f;
+
     public FakeConVar<bool> Enabled = new("botchat_enabled", "Enable bot chat messages", true);
     public FakeConVar<bool> StartEnabled = new("botchat_start_enabled", "Bots greet at match start", true);
     public FakeConVar<bool> EndEnabled = new("botchat_end_enabled", "Bots say goodbye at match end", true);
@@ -94,12 +99,14 @@ public class BotChatPlugin : BasePlugin
                 (bots[i], bots[j]) = (bots[j], bots[i]);
             }
 
+            float delay = baseDelay;
             for (int i = 0; i < speakers; i++)
             {
                 var bot = bots[i];
                 string message = PickMessage(pool, uniform);
-                int delayIdx = i;
-                AddTimer(baseDelay + delayIdx * 0.7f, () => BotSay(bot, message));
+                float scheduled = delay;
+                AddTimer(scheduled, () => BotSay(bot, message));
+                delay += MinGap + (float)Random.Shared.NextDouble() * (MaxGap - MinGap);
             }
         }
     }

--- a/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
+++ b/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
@@ -67,6 +67,11 @@ public class BotChatPlugin : BasePlugin
     private const double NiceShotHeadshotBonus = 0.05;
     private const double NiceShotBuffPerKillType = 0.20;
 
+    // Reaction delay after a death (seconds): 1.2 - 3.5s, so replies read
+    // like a human thinking, not an instant script.
+    private const float MinReactionDelay = 1.2f;
+    private const float MaxReactionDelay = 3.5f;
+
     // Guards the end messages against double-firing: the final round's win
     // panel and the match win panel may both be dispatched by the engine.
     private bool _endSaid;
@@ -223,7 +228,7 @@ public class BotChatPlugin : BasePlugin
                 Console.WriteLine(
                     $"[BotChat] owed-thanks += slot {attacker.Slot} ({attacker.PlayerName})");
             }
-            AddTimer(0.6f, () => BotSay(victim, PickMessage(NiceShotMessages, uniform: true)));
+            AddTimer(ReactionDelay(), () => BotSay(victim, PickMessage(NiceShotMessages, uniform: true)));
         }
 
         // 2) This victim, if it owed a thanks reply from an earlier ns, pays
@@ -233,7 +238,7 @@ public class BotChatPlugin : BasePlugin
         {
             Console.WriteLine(
                 $"[BotChat] death-thanks: {victimName} (slot {victim.Slot}) replies to {attackerName}");
-            AddTimer(0.6f, () => BotSay(victim, PickMessage(ThanksMessages, uniform: true)));
+            AddTimer(ReactionDelay(), () => BotSay(victim, PickMessage(ThanksMessages, uniform: true)));
         }
 
         return HookResult.Continue;
@@ -290,6 +295,10 @@ public class BotChatPlugin : BasePlugin
         }
     }
 
+    // Random reaction delay for death-related messages.
+    private static float ReactionDelay() =>
+        MinReactionDelay + (float)Random.Shared.NextDouble() * (MaxReactionDelay - MinReactionDelay);
+
     private static string PickMessage((string message, int weight)[] pool, bool uniform)
     {
         if (uniform)
@@ -327,3 +336,4 @@ public class BotChatPlugin : BasePlugin
         }
     }
 }
+

--- a/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
+++ b/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
@@ -1,0 +1,139 @@
+// BotChat plugin: bots greet at match start ("gl", "hf", ...) and wrap up
+// at match end ("gg", "ggs", ... , occasionally "ez").
+//
+// Convars:
+//   botchat_enabled        - master switch (default 1)
+//   botchat_start_enabled  - greetings at match start (default 1)
+//   botchat_end_enabled    - goodbyes at match end (default 1)
+
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Attributes.Registration;
+using CounterStrikeSharp.API.Modules.Cvars;
+using CounterStrikeSharp.API.Modules.Timers;
+using CounterStrikeSharp.API.Modules.Utils;
+
+namespace BotChat;
+
+public class BotChatPlugin : BasePlugin
+{
+    public override string ModuleName => "BotChat";
+    public override string ModuleVersion => "1.0.0";
+    public override string ModuleAuthor => "ed0ard";
+    public override string ModuleDescription =>
+        "Bots say a greeting at match start and a goodbye at match end";
+
+    // Messages a bot can greet with at match start (uniform pick).
+    private static readonly (string message, int weight)[] StartMessages =
+    {
+        ("gl", 1), ("hf", 1), ("glhf", 1), ("hfhf", 1), ("good luck", 1), ("have fun", 1),
+    };
+
+    // Messages a bot can say at match end (weighted pick, ez is rare).
+    private static readonly (string message, int weight)[] EndMessages =
+    {
+        ("gg", 45),
+        ("ggs", 30),
+        ("GG", 20),
+        ("ez", 5),
+    };
+
+    private const int MaxSpeakersPerTeam = 5;
+
+    public FakeConVar<bool> Enabled = new("botchat_enabled", "Enable bot chat messages", true);
+    public FakeConVar<bool> StartEnabled = new("botchat_start_enabled", "Bots greet at match start", true);
+    public FakeConVar<bool> EndEnabled = new("botchat_end_enabled", "Bots say goodbye at match end", true);
+
+    public override void Load(bool hotReload)
+    {
+        RegisterEventHandler<EventBeginNewMatch>(OnBeginNewMatch);
+        RegisterEventHandler<EventCsWinPanelMatch>(OnCsWinPanelMatch);
+    }
+
+    private HookResult OnBeginNewMatch(EventBeginNewMatch @event, GameEventInfo info)
+    {
+        if (!Enabled.Value || !StartEnabled.Value)
+            return HookResult.Continue;
+
+        SayAcrossTeams(StartMessages, uniform: true, baseDelay: 1.0f);
+        return HookResult.Continue;
+    }
+
+    private HookResult OnCsWinPanelMatch(EventCsWinPanelMatch @event, GameEventInfo info)
+    {
+        if (!Enabled.Value || !EndEnabled.Value)
+            return HookResult.Continue;
+
+        SayAcrossTeams(EndMessages, uniform: false, baseDelay: 1.5f);
+        return HookResult.Continue;
+    }
+
+    // Picks 1..5 random bots per team (humans and taken-over bots excluded)
+    // and makes each say one message, staggered in time.
+    private void SayAcrossTeams((string message, int weight)[] pool, bool uniform, float baseDelay)
+    {
+        foreach (var team in new[] { CsTeam.Terrorist, CsTeam.CounterTerrorist })
+        {
+            var bots = Utilities.FindAllEntitiesByDesignerName<CCSPlayerController>("cs_player_controller")
+                .Where(p => p.IsValid
+                    && p.IsBot
+                    && !p.IsHLTV
+                    && p.Team == team
+                    && !p.HasBeenControlledByPlayerThisRound)
+                .ToList();
+            if (bots.Count == 0)
+                continue;
+
+            int count = Math.Min(MaxSpeakersPerTeam, bots.Count);
+            int speakers = Random.Shared.Next(1, count + 1);
+
+            // Fisher-Yates shuffle, take the first `speakers`.
+            for (int i = bots.Count - 1; i > 0; i--)
+            {
+                int j = Random.Shared.Next(i + 1);
+                (bots[i], bots[j]) = (bots[j], bots[i]);
+            }
+
+            for (int i = 0; i < speakers; i++)
+            {
+                var bot = bots[i];
+                string message = PickMessage(pool, uniform);
+                int delayIdx = i;
+                AddTimer(baseDelay + delayIdx * 0.7f, () => BotSay(bot, message));
+            }
+        }
+    }
+
+    private static string PickMessage((string message, int weight)[] pool, bool uniform)
+    {
+        if (uniform)
+            return pool[Random.Shared.Next(pool.Length)].message;
+
+        int total = 0;
+        foreach (var (_, weight) in pool)
+            total += weight;
+
+        int roll = Random.Shared.Next(total);
+        foreach (var (message, weight) in pool)
+        {
+            if (roll < weight)
+                return message;
+            roll -= weight;
+        }
+        return pool[^1].message;
+    }
+
+    private static void BotSay(CCSPlayerController bot, string message)
+    {
+        if (bot == null || !bot.IsValid)
+            return;
+        try
+        {
+            bot.ExecuteClientCommandFromServer($"say {message}");
+        }
+        catch
+        {
+            Console.WriteLine($"[BotChat] failed to make bot {bot.PlayerName} say '{message}'");
+        }
+    }
+}

--- a/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
+++ b/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
@@ -180,8 +180,12 @@ public class BotChatPlugin : BasePlugin
         if (victim == null || !victim.IsValid || !victim.IsBot || victim.IsHLTV)
             return HookResult.Continue;
 
-        // 1) Victim: compliment a headshot (ns / nc / nice shot). If it rolls
-        // in, the killer owes a thanks reply (on its death or at round end).
+        string victimName = victim.PlayerName;
+        string attackerName = attacker != null && attacker.IsValid ? attacker.PlayerName : "world";
+
+        // 1) Victim: compliment a headshot (ns / nc / nice shot). Works for
+        // any killer (bot or human). If it rolls in and the killer is a bot,
+        // it owes a thanks reply (on its death or at round end).
         if (@event.Headshot)
         {
             double chance = NiceShotBaseChance;
@@ -190,7 +194,15 @@ public class BotChatPlugin : BasePlugin
             if (@event.Penetrated > 0) chance += NiceShotBuffPerKillType;
             if (@event.Attackerinair) chance += NiceShotBuffPerKillType;
 
-            if (Random.Shared.NextDouble() < chance)
+            double roll = Random.Shared.NextDouble();
+            bool complimented = roll < chance;
+
+            Console.WriteLine(
+                $"[BotChat] death: victim={victimName}(bot) killer={attackerName} headshot " +
+                $"chance={chance:P0} roll={roll:P2} -> {(complimented ? "ns" : "silent")} " +
+                $"(blind={@event.Attackerblind} smoke={@event.Thrusmoke} wall={@event.Penetrated} air={@event.Attackerinair})");
+
+            if (complimented)
             {
                 if (attacker != null && attacker.IsValid && attacker.IsBot
                     && !attacker.IsHLTV
@@ -198,6 +210,8 @@ public class BotChatPlugin : BasePlugin
                     && attacker.Slot != victim.Slot)
                 {
                     _owedThanks.Add(attacker.Slot);
+                    Console.WriteLine(
+                        $"[BotChat] owed-thanks += slot {attacker.Slot} ({attacker.PlayerName})");
                 }
                 AddTimer(0.6f, () => BotSay(victim, PickMessage(NiceShotMessages, uniform: true)));
             }
@@ -210,6 +224,8 @@ public class BotChatPlugin : BasePlugin
             && attacker.Slot != victim.Slot
             && _owedThanks.Remove(attacker.Slot))
         {
+            Console.WriteLine(
+                $"[BotChat] death-thanks: killer={attacker.PlayerName} (slot {attacker.Slot}) replies to {victimName}");
             AddTimer(0.6f, () => BotSay(attacker, PickMessage(ThanksMessages, uniform: true)));
         }
 
@@ -289,14 +305,18 @@ public class BotChatPlugin : BasePlugin
     private static void BotSay(CCSPlayerController bot, string message)
     {
         if (bot == null || !bot.IsValid)
+        {
+            Console.WriteLine($"[BotChat] say skipped: bot invalid");
             return;
+        }
         try
         {
             bot.ExecuteClientCommandFromServer($"say {message}");
+            Console.WriteLine($"[BotChat] said '{message}' as {bot.PlayerName} (slot {bot.Slot})");
         }
-        catch
+        catch (Exception ex)
         {
-            Console.WriteLine($"[BotChat] failed to make bot {bot.PlayerName} say '{message}'");
+            Console.WriteLine($"[BotChat] failed to make bot {bot.PlayerName} say '{message}': {ex.Message}");
         }
     }
 }

--- a/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
+++ b/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
@@ -172,11 +172,20 @@ public class BotChatPlugin : BasePlugin
     // killer replies thanks after its own death.
     private HookResult OnPlayerDeath(EventPlayerDeath @event, GameEventInfo info)
     {
+        var victim = @event.Userid;
+        var attacker = @event.Attacker;
+
+        // Log EVERY death to the server console so we can tell apart a missed
+        // event from a failed probability roll.
+        Console.WriteLine(
+            $"[BotChat] death event: victim={victim?.PlayerName ?? "?"}(bot={victim?.IsBot}) " +
+            $"killer={attacker?.PlayerName ?? "world"}(bot={attacker?.IsBot}) " +
+            $"headshot={@event.Headshot} blind={@event.Attackerblind} smoke={@event.Thrusmoke} " +
+            $"wall={@event.Penetrated} air={@event.Attackerinair}");
+
         if (!Enabled.Value || !KillReactionsEnabled.Value)
             return HookResult.Continue;
 
-        var victim = @event.Userid;
-        var attacker = @event.Attacker;
         if (victim == null || !victim.IsValid || !victim.IsBot || victim.IsHLTV)
             return HookResult.Continue;
 
@@ -198,9 +207,8 @@ public class BotChatPlugin : BasePlugin
             bool complimented = roll < chance;
 
             Console.WriteLine(
-                $"[BotChat] death: victim={victimName}(bot) killer={attackerName} headshot " +
-                $"chance={chance:P0} roll={roll:P2} -> {(complimented ? "ns" : "silent")} " +
-                $"(blind={@event.Attackerblind} smoke={@event.Thrusmoke} wall={@event.Penetrated} air={@event.Attackerinair})");
+                $"[BotChat] ns roll: victim={victimName} killer={attackerName} " +
+                $"chance={chance:P0} roll={roll:P2} -> {(complimented ? "ns" : "silent")}");
 
             if (complimented)
             {

--- a/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
+++ b/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
@@ -70,8 +70,9 @@ public class BotChatPlugin : BasePlugin
     // panel and the match win panel may both be dispatched by the engine.
     private bool _endSaid;
 
-    // Bots that killed someone this round, by slot. Used at round end.
-    private readonly HashSet<int> _killersThisRound = new();
+    // Bots that owe a thanks reply this round (their shot got complimented
+    // with "ns"). They thank on their own death, or at round end if alive.
+    private readonly HashSet<int> _owedThanks = new();
 
     public FakeConVar<bool> Enabled = new("botchat_enabled", "Enable bot chat messages", true);
     public FakeConVar<bool> StartEnabled = new("botchat_start_enabled", "Bots greet at match start", true);
@@ -129,35 +130,46 @@ public class BotChatPlugin : BasePlugin
         SayAcrossTeams(EndMessages, uniform: false, baseDelay: 1.5f);
     }
 
-    // Clears per-round kill tracking.
+    // Clears per-round state.
     private HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
     {
-        _killersThisRound.Clear();
+        _owedThanks.Clear();
         return HookResult.Continue;
     }
 
-    // Round end: bots that killed this round and are still alive say thanks.
+    // Round end: every bot that got complimented this round and is still
+    // alive replies thanks individually.
     private HookResult OnRoundEnd(EventRoundEnd @event, GameEventInfo info)
     {
         if (!Enabled.Value || !KillReactionsEnabled.Value)
             return HookResult.Continue;
 
-        var aliveKillers = Utilities.FindAllEntitiesByDesignerName<CCSPlayerController>("cs_player_controller")
+        var aliveThankers = Utilities.FindAllEntitiesByDesignerName<CCSPlayerController>("cs_player_controller")
             .Where(p => p.IsValid
                 && p.IsBot
                 && !p.IsHLTV
                 && !p.HasBeenControlledByPlayerThisRound
                 && p.PawnIsAlive
-                && _killersThisRound.Contains(p.Slot))
+                && _owedThanks.Contains(p.Slot))
             .ToList();
-        if (aliveKillers.Count == 0)
+        if (aliveThankers.Count == 0)
             return HookResult.Continue;
 
-        SayRandom(aliveKillers, ThanksMessages, uniform: true, baseDelay: 0.8f);
+        // Every one of them talks, staggered like a natural conversation.
+        float delay = 0.8f;
+        foreach (var bot in aliveThankers)
+        {
+            string message = PickMessage(ThanksMessages, uniform: true);
+            float scheduled = delay;
+            AddTimer(scheduled, () => BotSay(bot, message));
+            delay += MinGap + (float)Random.Shared.NextDouble() * (MaxGap - MinGap);
+        }
+
         return HookResult.Continue;
     }
 
-    // Death reactions: the headshot victim may compliment, the killer thanks.
+    // Death reactions: the headshot victim may compliment, the complimented
+    // killer replies thanks after its own death.
     private HookResult OnPlayerDeath(EventPlayerDeath @event, GameEventInfo info)
     {
         if (!Enabled.Value || !KillReactionsEnabled.Value)
@@ -168,7 +180,8 @@ public class BotChatPlugin : BasePlugin
         if (victim == null || !victim.IsValid || !victim.IsBot || victim.IsHLTV)
             return HookResult.Continue;
 
-        // 1) Victim: compliment a headshot (ns / nc / nice shot).
+        // 1) Victim: compliment a headshot (ns / nc / nice shot). If it rolls
+        // in, the killer owes a thanks reply (on its death or at round end).
         if (@event.Headshot)
         {
             double chance = NiceShotBaseChance;
@@ -179,17 +192,24 @@ public class BotChatPlugin : BasePlugin
 
             if (Random.Shared.NextDouble() < chance)
             {
-                var killer = attacker;
+                if (attacker != null && attacker.IsValid && attacker.IsBot
+                    && !attacker.IsHLTV
+                    && !attacker.HasBeenControlledByPlayerThisRound
+                    && attacker.Slot != victim.Slot)
+                {
+                    _owedThanks.Add(attacker.Slot);
+                }
                 AddTimer(0.6f, () => BotSay(victim, PickMessage(NiceShotMessages, uniform: true)));
             }
         }
 
-        // 2) Killer: thanks after dying.
+        // 2) Complimented killer: reply thanks after dying (one reply only;
+        // the owed entry is consumed here so the round end won't repeat it).
         if (attacker != null && attacker.IsValid && attacker.IsBot && !attacker.IsHLTV
             && !attacker.HasBeenControlledByPlayerThisRound
-            && attacker.Slot != victim.Slot)
+            && attacker.Slot != victim.Slot
+            && _owedThanks.Remove(attacker.Slot))
         {
-            _killersThisRound.Add(attacker.Slot);
             AddTimer(0.6f, () => BotSay(attacker, PickMessage(ThanksMessages, uniform: true)));
         }
 

--- a/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
+++ b/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
@@ -45,18 +45,29 @@ public class BotChatPlugin : BasePlugin
     private const float MinGap = 1.2f;
     private const float MaxGap = 3.0f;
 
+    // Guards the end messages against double-firing: the final round's win
+    // panel and the match win panel may both be dispatched by the engine.
+    private bool _endSaid;
+
     public FakeConVar<bool> Enabled = new("botchat_enabled", "Enable bot chat messages", true);
     public FakeConVar<bool> StartEnabled = new("botchat_start_enabled", "Bots greet at match start", true);
     public FakeConVar<bool> EndEnabled = new("botchat_end_enabled", "Bots say goodbye at match end", true);
 
     public override void Load(bool hotReload)
     {
+        RegisterListener<Listeners.OnMapStart>(_ => _endSaid = false);
         RegisterEventHandler<EventBeginNewMatch>(OnBeginNewMatch);
+        // cs_win_panel_round fires at the end of every round; FinalEvent = 1
+        // marks the final round of the match. More reliable than
+        // cs_win_panel_match in offline bot matches, where that event may
+        // never be dispatched.
+        RegisterEventHandler<EventCsWinPanelRound>(OnCsWinPanelRound);
         RegisterEventHandler<EventCsWinPanelMatch>(OnCsWinPanelMatch);
     }
 
     private HookResult OnBeginNewMatch(EventBeginNewMatch @event, GameEventInfo info)
     {
+        _endSaid = false;
         if (!Enabled.Value || !StartEnabled.Value)
             return HookResult.Continue;
 
@@ -64,13 +75,30 @@ public class BotChatPlugin : BasePlugin
         return HookResult.Continue;
     }
 
-    private HookResult OnCsWinPanelMatch(EventCsWinPanelMatch @event, GameEventInfo info)
+    private HookResult OnCsWinPanelRound(EventCsWinPanelRound @event, GameEventInfo info)
     {
-        if (!Enabled.Value || !EndEnabled.Value)
+        if (@event.FinalEvent == 0)
             return HookResult.Continue;
 
-        SayAcrossTeams(EndMessages, uniform: false, baseDelay: 1.5f);
+        SayEndMessages();
         return HookResult.Continue;
+    }
+
+    private HookResult OnCsWinPanelMatch(EventCsWinPanelMatch @event, GameEventInfo info)
+    {
+        SayEndMessages();
+        return HookResult.Continue;
+    }
+
+    private void SayEndMessages()
+    {
+        if (_endSaid)
+            return;
+        if (!Enabled.Value || !EndEnabled.Value)
+            return;
+
+        _endSaid = true;
+        SayAcrossTeams(EndMessages, uniform: false, baseDelay: 1.5f);
     }
 
     // Picks 1..5 random bots per team (humans and taken-over bots excluded)

--- a/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
+++ b/addons/counterstrikesharp/plugins/BotChat/BotChat.cs
@@ -61,9 +61,10 @@ public class BotChatPlugin : BasePlugin
     private const float MinGap = 1.2f;
     private const float MaxGap = 3.0f;
 
-    // Base chance (0-1) a headshot victim says "ns" after death. Each kill
-    // type (blind, smoke, wallbang, jump) adds this much on top.
+    // Base chance (0-1) a victim says "ns" after any kill. Headshot raises
+    // it, and each kill type (blind, smoke, wallbang, jump) adds on top.
     private const double NiceShotBaseChance = 0.05;
+    private const double NiceShotHeadshotBonus = 0.05;
     private const double NiceShotBuffPerKillType = 0.20;
 
     // Guards the end messages against double-firing: the final round's win
@@ -192,37 +193,37 @@ public class BotChatPlugin : BasePlugin
         string victimName = victim.PlayerName;
         string attackerName = attacker != null && attacker.IsValid ? attacker.PlayerName : "world";
 
-        // 1) Victim: compliment a headshot (ns / nc / nice shot). Works for
-        // any killer (bot or human). If it rolls in and the killer is a bot,
-        // it owes a thanks reply (on its death or at round end).
-        if (@event.Headshot)
+        // 1) Victim: compliment a kill (ns / nc / nice shot). Any kill can
+        // trigger; headshot raises the chance. If it rolls in and the killer
+        // is a bot, it owes a thanks reply (on its death or at round end).
+        double chance = NiceShotBaseChance;
+        if (@event.Headshot) chance += NiceShotHeadshotBonus;
+        if (@event.Attackerblind) chance += NiceShotBuffPerKillType;
+        if (@event.Thrusmoke) chance += NiceShotBuffPerKillType;
+        if (@event.Penetrated > 0) chance += NiceShotBuffPerKillType;
+        if (@event.Attackerinair) chance += NiceShotBuffPerKillType;
+
+        double roll = Random.Shared.NextDouble();
+        bool complimented = roll < chance;
+
+        Console.WriteLine(
+            $"[BotChat] ns roll: victim={victimName} killer={attackerName} " +
+            $"chance={chance:P0} roll={roll:P2} -> {(complimented ? "ns" : "silent")} " +
+            $"(headshot={@event.Headshot} blind={@event.Attackerblind} smoke={@event.Thrusmoke} " +
+            $"wall={@event.Penetrated} air={@event.Attackerinair})");
+
+        if (complimented)
         {
-            double chance = NiceShotBaseChance;
-            if (@event.Attackerblind) chance += NiceShotBuffPerKillType;
-            if (@event.Thrusmoke) chance += NiceShotBuffPerKillType;
-            if (@event.Penetrated > 0) chance += NiceShotBuffPerKillType;
-            if (@event.Attackerinair) chance += NiceShotBuffPerKillType;
-
-            double roll = Random.Shared.NextDouble();
-            bool complimented = roll < chance;
-
-            Console.WriteLine(
-                $"[BotChat] ns roll: victim={victimName} killer={attackerName} " +
-                $"chance={chance:P0} roll={roll:P2} -> {(complimented ? "ns" : "silent")}");
-
-            if (complimented)
+            if (attacker != null && attacker.IsValid && attacker.IsBot
+                && !attacker.IsHLTV
+                && !attacker.HasBeenControlledByPlayerThisRound
+                && attacker.Slot != victim.Slot)
             {
-                if (attacker != null && attacker.IsValid && attacker.IsBot
-                    && !attacker.IsHLTV
-                    && !attacker.HasBeenControlledByPlayerThisRound
-                    && attacker.Slot != victim.Slot)
-                {
-                    _owedThanks.Add(attacker.Slot);
-                    Console.WriteLine(
-                        $"[BotChat] owed-thanks += slot {attacker.Slot} ({attacker.PlayerName})");
-                }
-                AddTimer(0.6f, () => BotSay(victim, PickMessage(NiceShotMessages, uniform: true)));
+                _owedThanks.Add(attacker.Slot);
+                Console.WriteLine(
+                    $"[BotChat] owed-thanks += slot {attacker.Slot} ({attacker.PlayerName})");
             }
+            AddTimer(0.6f, () => BotSay(victim, PickMessage(NiceShotMessages, uniform: true)));
         }
 
         // 2) Complimented killer: reply thanks after dying (one reply only;

--- a/addons/counterstrikesharp/plugins/BotChat/BotChat.csproj
+++ b/addons/counterstrikesharp/plugins/BotChat/BotChat.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>BotChat</AssemblyName>
+    <RootNamespace>BotChat</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.371" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Add a new `BotChat` plugin that makes bots talk in chat to make offline/friend matches feel more alive:

- **Match start**: 1–5 random bots per team greet with `gl / hf / glhf / hfhf / good luck / have fun`
- **Match end**: 1–5 random bots per team say `gg / ggs / GG`, rarely `ez` (5%)
- **Kill reactions**:
  - A victim may compliment the kill with `ns / nc / nice shot` — any kill can trigger (base 5%), headshot raises it to 10%, and each of blind / smoke / wallbang / jump adds +20%
  - The complimented killer replies with `ty / thanks / thank u / thx / life game / luck / :)` when it dies, or at round end if it survived
- All messages are staggered with random 1.2–3.0s gaps so they read like a natural conversation; death reactions have a 1.2–3.5s human-like delay
- Convars: `botchat_enabled`, `botchat_start_enabled`, `botchat_end_enabled`, `botchat_killreactions_enabled` (all on by default)
- Detailed `[BotChat]` server-console logging for death reactions (chance roll, buffs, send result)

## Implementation notes

- Uses `begin_new_match` for the greeting; `cs_win_panel_round` (`FinalEvent=1`) fires the goodbye since `cs_win_panel_match` does not fire in offline bot matches, with the match panel kept as a backup and a guard against double-firing
- Sends chat via `CCSPlayerController.ExecuteClientCommandFromServer("say ...")`, which works for bots (fake clients)
- New plugin follows the existing one-plugin-per-folder layout, targets net10.0 / CSS API 1.0.371, builds clean

## Tested

- Verified in-game: start greetings, end goodbyes, ns → thanks conversation chain, convar toggles, no errors on reload